### PR TITLE
ci: migrate all GitHub workflows to use self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   # Code quality checks
   quality:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
 
   # Code coverage
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     needs: [quality, test]
     steps:
       - name: 📚 Git Checkout
@@ -103,7 +103,7 @@ jobs:
 
   # Performance testing
   performance:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     if: github.event_name == 'pull_request'
     needs: [quality]
     steps:
@@ -129,7 +129,7 @@ jobs:
 
   # Security scanning
   security:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
@@ -157,7 +157,7 @@ jobs:
 
   # Documentation generation test
   docs:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
@@ -180,7 +180,7 @@ jobs:
 
   # CI results summary
   ci-success:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     needs: [quality, test, coverage, security, docs]
     if: always()
     steps:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
@@ -157,7 +157,7 @@ jobs:
 
   # Verify publication success
   verify-publish:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     if: ${{ inputs.run_publish || startsWith(github.ref, 'refs/tags/') }}
     needs: release
     steps:


### PR DESCRIPTION
Uses self-hosted runners instead of ubuntu-latest