### PR TITLE
refactor(builder): split schema generator into cohesive files

### DIFF
--- a/packages/firestore_odm_builder/lib/src/generators/schema_generator.class_type.dart
+++ b/packages/firestore_odm_builder/lib/src/generators/schema_generator.class_type.dart
@@ -1,0 +1,23 @@
+part of 'schema_generator.dart';
+
+final preferInlineAnnotation = refer(
+  'pragma',
+).call([literalString('vm:prefer-inline')]);
+final overrideAnnotation = refer('override');
+
+enum ClassType {
+  root('Root'),
+  collection('Collection'),
+  document('Document'),
+  transactionContext('TransactionContext'),
+  transactionCollection('TransactionCollection'),
+  transactionDocument('TransactionDocument'),
+  batchContext('BatchContext'),
+  batchCollection('BatchCollection'),
+  batchDocument('BatchDocument'),
+  patchBuilder('PatchBuilder');
+
+  const ClassType(this.suffix);
+
+  final String suffix;
+}

--- a/packages/firestore_odm_builder/lib/src/generators/schema_generator.collection_info.dart
+++ b/packages/firestore_odm_builder/lib/src/generators/schema_generator.collection_info.dart
@@ -1,0 +1,18 @@
+part of 'schema_generator.dart';
+
+/// Information about a collection annotation extracted from a schema variable
+class SchemaCollectionInfo {
+  final String path;
+  final String modelTypeName;
+  final bool isSubcollection;
+  final String schemaTypeName;
+  final InterfaceType modelType;
+
+  const SchemaCollectionInfo({
+    required this.path,
+    required this.modelTypeName,
+    required this.isSubcollection,
+    required this.schemaTypeName,
+    required this.modelType,
+  });
+}

--- a/packages/firestore_odm_builder/lib/src/generators/schema_generator.dart
+++ b/packages/firestore_odm_builder/lib/src/generators/schema_generator.dart
@@ -13,44 +13,8 @@ import 'package:source_gen/source_gen.dart';
 
 import '../utils/model_analyzer.dart';
 
-/// Information about a collection annotation extracted from a schema variable
-class SchemaCollectionInfo {
-  final String path;
-  final String modelTypeName;
-  final bool isSubcollection;
-  final String schemaTypeName;
-  final InterfaceType modelType;
-
-  const SchemaCollectionInfo({
-    required this.path,
-    required this.modelTypeName,
-    required this.isSubcollection,
-    required this.schemaTypeName,
-    required this.modelType,
-  });
-}
-
-final preferInlineAnnotation = refer(
-  'pragma',
-).call([literalString('vm:prefer-inline')]);
-final overrideAnnotation = refer('override');
-
-enum ClassType {
-  root('Root'),
-  collection('Collection'),
-  document('Document'),
-  transactionContext('TransactionContext'),
-  transactionCollection('TransactionCollection'),
-  transactionDocument('TransactionDocument'),
-  batchContext('BatchContext'),
-  batchCollection('BatchCollection'),
-  batchDocument('BatchDocument'),
-  patchBuilder('PatchBuilder');
-
-  const ClassType(this.suffix);
-
-  final String suffix;
-}
+part 'schema_generator.collection_info.dart';
+part 'schema_generator.class_type.dart';
 
 /// Generator for schema-based ODM code using code_builder
 class SchemaGenerator {


### PR DESCRIPTION
## What

Splits the ~1034-LOC hand-written code-generator source `packages/firestore_odm_builder/lib/src/generators/schema_generator.dart` into cohesive same-library files, extracting the independent top-level declarations while keeping the tightly-coupled `SchemaGenerator` core whole.

| File | Contents |
|------|----------|
| `schema_generator.dart` (main library) | imports + the `SchemaGenerator` class (20 mutually-referencing static emit methods + shared private helpers) |
| `schema_generator.collection_info.dart` (part) | `SchemaCollectionInfo` data class — the externally-consumed collection-annotation model |
| `schema_generator.class_type.dart` (part) | `ClassType` enum + the `preferInlineAnnotation` / `overrideAnnotation` emit primitives |

## How

Pure mechanical move via Dart `part` / `part of`. **Zero logic change** — the diff is a verbatim relocation of declarations plus two `part` directives. The `SchemaGenerator` class itself is left intact because Dart does not allow a single class body to be split across part files, and its static methods are tightly coupled through shared private helpers (`_getPathRecord`, `_getCollectionName`, `_getSegments`, `getSubcollections`, …).

## Public API: byte-for-byte preserved

Part files share the parent library's scope, so every top-level name (`SchemaGenerator`, `SchemaCollectionInfo`, `ClassType`, `preferInlineAnnotation`, `overrideAnnotation`) remains importable identically. Consumers (`src/schema_generator.dart`, `src/builder.dart`, and the public export `firestore_odm_builder.dart`) are unchanged.

## Gates vs baseline

Run locally with Dart SDK 3.12.2 on the `firestore_odm_builder` package:

- **`dart analyze`**: `129 issues found`, RC=0 — **identical to baseline** (all pre-existing `info`-level analyzer-element-model deprecations; no errors/warnings; no new issues from the split).
- **`dart format --output=none --set-exit-if-changed`**: the two new part files are clean (`0 changed`); the package-wide changed-file set is **unchanged from baseline**. (The baseline format check is already red on this package due to a formatter-version skew between local Dart 3.12.2 and the version the repo was last formatted with — it affects 12 pre-existing untouched files; this PR adds nothing to that set.)
- **`dart test`**: the builder package has no `test/` directory; generator behavior is exercised by the `flutter_example` integration tests in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)