### PR TITLE
fix: nullable cast for nested fromJson factories accepting nullable input (closes #5)

### DIFF
--- a/apps/flutter_example/lib/models/defaulted_nested_test.dart
+++ b/apps/flutter_example/lib/models/defaulted_nested_test.dart
@@ -1,0 +1,62 @@
+/// Test model for nullable-input `fromJson` factories on non-nullable fields.
+///
+/// Regression coverage for GitHub Issue #5:
+/// https://github.com/SylphxAI/firestore_odm/issues/5
+///
+/// A nested class whose `fromJson` factory accepts a **nullable** map parameter
+/// (and gracefully returns a default for null) must be deserialized with a
+/// **nullable** cast even when the parent field is non-nullable. Otherwise a
+/// Firestore document that predates the field crashes with
+/// `type 'Null' is not a subtype of type 'Map<String, Object?>' in type cast`.
+///
+/// The parent (`OrderWithDefault`) deliberately has NO custom `fromJson`/
+/// `toJson`, so the firestore_odm builder generates `$OrderWithDefaultFromJson`
+/// itself — the function that contained the buggy non-nullable cast.
+library;
+
+import 'package:firestore_odm/firestore_odm.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'defaulted_nested_test.g.dart';
+
+/// Nested object whose `fromJson` accepts a nullable map and falls back to a
+/// default instance when the value is absent — mirrors the issue's `Address`.
+@JsonSerializable()
+@firestoreOdm
+class DefaultedAddress {
+  const DefaultedAddress({this.street = '', this.city = ''});
+
+  factory DefaultedAddress.fromJson(Map<String, Object?>? json) => json == null
+      ? const DefaultedAddress()
+      : _$DefaultedAddressFromJson(json);
+
+  @JsonKey(defaultValue: '')
+  final String street;
+  @JsonKey(defaultValue: '')
+  final String city;
+
+  Map<String, dynamic> toJson() => _$DefaultedAddressToJson(this);
+}
+
+/// Parent model with a **non-nullable** nested field that has a default value.
+///
+/// No custom `fromJson`/`toJson`: the firestore_odm builder generates the
+/// converter, exercising the nullable-cast logic for the nested field.
+@firestoreOdm
+class OrderWithDefault {
+  const OrderWithDefault({
+    required this.id,
+    required this.productId,
+    this.shippingAddress = const DefaultedAddress(),
+  });
+
+  @DocumentIdField()
+  final String id;
+
+  final String productId;
+
+  /// Non-nullable, with a default. The generated `$OrderWithDefaultFromJson`
+  /// must use a nullable cast here because `DefaultedAddress.fromJson` accepts
+  /// a nullable map.
+  final DefaultedAddress shippingAddress;
+}

--- a/apps/flutter_example/lib/test_schema.dart
+++ b/apps/flutter_example/lib/test_schema.dart
@@ -1,6 +1,7 @@
 import 'package:firestore_odm/firestore_odm.dart';
 import 'package:flutter_example/models/comment.dart';
 import 'package:flutter_example/models/dart_immutable_user.dart';
+import 'package:flutter_example/models/defaulted_nested_test.dart';
 import 'package:flutter_example/models/immutable_user.dart';
 import 'package:flutter_example/models/json_key_user.dart';
 import 'package:flutter_example/models/list_length_model.dart';
@@ -73,4 +74,7 @@ part 'test_schema.g.dart';
   'nullableTypesTests',
 ) // Issue #3: nullable types test
 @Collection<NestedData>('nestedData') // Nested data for issue #3 testing
+@Collection<OrderWithDefault>(
+  'orderWithDefaults',
+) // Issue #5: nullable-input fromJson on non-nullable field
 const TestSchema testSchema = _$TestSchema;

--- a/apps/flutter_example/test/defaulted_nested_test.dart
+++ b/apps/flutter_example/test/defaulted_nested_test.dart
@@ -1,0 +1,93 @@
+/// Regression test for GitHub Issue #5:
+/// https://github.com/SylphxAI/firestore_odm/issues/5
+///
+/// The generated `$ModelFromJson` must use a **nullable** cast for a nested
+/// object field whose `fromJson` factory accepts a nullable map — even when the
+/// parent field is non-nullable with a default. Otherwise, reading a Firestore
+/// document that predates the field crashes with:
+///   type 'Null' is not a subtype of type 'Map<String, Object?>' in type cast
+library;
+
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firestore_odm/firestore_odm.dart';
+import 'package:flutter_example/models/defaulted_nested_test.dart';
+import 'package:flutter_example/test_schema.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late FakeFirebaseFirestore firestore;
+  late FirestoreODM<TestSchema> db;
+
+  setUp(() {
+    firestore = FakeFirebaseFirestore();
+    db = FirestoreODM(testSchema, firestore: firestore);
+  });
+
+  group('Issue #5: nullable-input fromJson on non-nullable nested field', () {
+    test(
+      'reads a legacy document missing the nested field without crashing',
+      () async {
+        // Simulate a document created before `shippingAddress` existed: write
+        // raw data directly, bypassing the ODM's toJson so the field is absent.
+        await firestore.collection('orderWithDefaults').doc('legacy').set({
+          'productId': 'p1',
+        });
+
+        final result = await db.orderWithDefaults('legacy').get();
+
+        expect(result, isNotNull);
+        expect(result!.productId, equals('p1'));
+        // The nullable-aware cast lets DefaultedAddress.fromJson(null) return
+        // the default instance instead of throwing.
+        expect(result.shippingAddress.street, equals(''));
+        expect(result.shippingAddress.city, equals(''));
+      },
+    );
+
+    test('reads a document with an explicit null nested field', () async {
+      await firestore.collection('orderWithDefaults').doc('explicitNull').set({
+        'productId': 'p2',
+        'shippingAddress': null,
+      });
+
+      final result = await db.orderWithDefaults('explicitNull').get();
+
+      expect(result, isNotNull);
+      expect(result!.shippingAddress.street, equals(''));
+      expect(result.shippingAddress.city, equals(''));
+    });
+
+    test('round-trips a populated nested field', () async {
+      const order = OrderWithDefault(
+        id: 'full',
+        productId: 'p3',
+        shippingAddress: DefaultedAddress(
+          street: '1 Main St',
+          city: 'Metropolis',
+        ),
+      );
+
+      await db.orderWithDefaults.insert(order);
+      final result = await db.orderWithDefaults('full').get();
+
+      expect(result, isNotNull);
+      expect(result!.productId, equals('p3'));
+      expect(result.shippingAddress.street, equals('1 Main St'));
+      expect(result.shippingAddress.city, equals('Metropolis'));
+    });
+
+    test(
+      'uses the constructor default when inserted without an address',
+      () async {
+        const order = OrderWithDefault(id: 'defaulted', productId: 'p4');
+
+        await db.orderWithDefaults.insert(order);
+        final result = await db.orderWithDefaults('defaulted').get();
+
+        expect(result, isNotNull);
+        expect(result!.shippingAddress.street, equals(''));
+        expect(result.shippingAddress.city, equals(''));
+      },
+    );
+  });
+}

--- a/packages/firestore_odm_builder/lib/src/generators/converter_generator.dart
+++ b/packages/firestore_odm_builder/lib/src/generators/converter_generator.dart
@@ -319,8 +319,15 @@ class ConverterGenerator {
         // to ensure we cast to the correct type (e.g., Map<String, Object?> vs Map<String, dynamic>)
         final firstParam = fromJson.formalParameters.firstOrNull;
         final paramType = firstParam?.type.reference ?? getJsonType(type: type);
+        // The cast must be nullable when EITHER the field is nullable OR the
+        // fromJson factory itself accepts a nullable parameter. A factory that
+        // declares a nullable parameter (e.g. `Address.fromJson(Map? json)`) is
+        // designed to handle a missing/null value, so forcing a non-nullable
+        // cast would crash at runtime when the field is absent in Firestore.
+        final castIsNullable =
+            type.isNullable || (paramType.isNullable ?? false);
         final invokeExp = type.reference.property('fromJson').call([
-          value.asA(paramType.withNullability(type.isNullable)),
+          value.asA(paramType.withNullability(castIsNullable)),
           ...args,
         ]);
         // If the type has a toJson method, use it directly


### PR DESCRIPTION
## Summary

Fixes #5. The generated `\$ModelFromJson` produced a **non-nullable** cast for a nested object field whose `fromJson` factory accepts a **nullable** map, crashing at runtime when the field was absent from a Firestore document:

```
type 'Null' is not a subtype of type 'Map<String, Object?>' in type cast
```

## Root cause

In `ConverterGenerator.callFromJson` (`packages/firestore_odm_builder/lib/src/generators/converter_generator.dart`), the cast for a nested field with a custom `fromJson` factory used `paramType.withNullability(type.isNullable)` — forcing the **field's** nullability onto the cast and discarding the nullability declared by the **factory's parameter**.

So a non-nullable field (`Address shippingAddress = const Address()`) whose factory is `Address.fromJson(Map<String, Object?>? json)` generated:

```dart
shippingAddress: Address.fromJson((data['shippingAddress'] as Map<String, Object?>)) // crashes on null
```

## Fix

The cast is now nullable when **either** the field is nullable **or** the factory's parameter type is nullable:

```dart
final castIsNullable = type.isNullable || (paramType.isNullable ?? false);
```

Generated output is now:

```dart
shippingAddress: DefaultedAddress.fromJson((data['shippingAddress'] as Map<String, Object?>?))
```

which lets `DefaultedAddress.fromJson(null)` return its default instance, exactly as the factory was designed to.

## Tests

Added `apps/flutter_example/lib/models/defaulted_nested_test.dart` + `apps/flutter_example/test/defaulted_nested_test.dart`:

- `OrderWithDefault` has **no** custom `fromJson`, so firestore_odm generates the converter (the buggy code path).
- `DefaultedAddress` has a custom `fromJson` accepting a nullable map.

Verified by reverting the fix: the "legacy document missing the field" and "explicit null" tests reproduce the exact reported crash; with the fix, all pass.

Full suite: **503 passed, 9 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)