### PR TITLE
ci: retry Flutter clone + guard engine version on self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,20 +28,32 @@ jobs:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
 
-      - name: 🐦 Setup Flutter (git)
+      - name: 🐦 Setup Flutter & Bootstrap
         run: |
-          git clone --depth 1 -b 3.32.8 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter"
+          # These self-hosted runners intermittently produce an incomplete
+          # Flutter checkout (empty bin/internal/engine.version), which yields a
+          # broken `flutter//flutter_gpu.zip` URL and a failed bootstrap. Re-clone
+          # until the engine version is present, precache serially before melos'
+          # concurrent pub gets, and retry to absorb transient failures.
+          export PATH="$RUNNER_TEMP/flutter/bin:$HOME/.pub-cache/bin:$PATH"
+          ok=0
+          for attempt in 1 2 3; do
+            rm -rf "$RUNNER_TEMP/flutter"
+            git clone --depth 1 -b 3.32.8 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter" \
+              || { echo "::warning::clone failed (attempt $attempt)"; sleep 10; continue; }
+            if [ ! -s "$RUNNER_TEMP/flutter/bin/internal/engine.version" ]; then
+              echo "::warning::empty engine.version (attempt $attempt); re-cloning"; sleep 10; continue
+            fi
+            flutter --version \
+              && flutter precache \
+              && dart pub global activate melos \
+              && melos bootstrap \
+              && { ok=1; break; }
+            echo "::warning::setup/bootstrap failed (attempt $attempt); retrying"; sleep 10
+          done
+          [ "$ok" = 1 ] || { echo "Flutter setup/bootstrap failed after retries"; exit 1; }
           echo "$RUNNER_TEMP/flutter/bin" >> "$GITHUB_PATH"
           echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
-
-      - name: 🔧 Setup Melos
-        run: |
-          flutter --version
-          flutter precache
-          dart pub global activate melos
-
-      - name: 📦 Bootstrap Dependencies
-        run: melos bootstrap
 
       - name: 🎨 Check Code Formatting
         run: melos run format:check --no-select
@@ -96,20 +108,32 @@ jobs:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
 
-      - name: 🐦 Setup Flutter (git)
+      - name: 🐦 Setup Flutter & Bootstrap
         run: |
-          git clone --depth 1 -b 3.32.8 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter"
+          # These self-hosted runners intermittently produce an incomplete
+          # Flutter checkout (empty bin/internal/engine.version), which yields a
+          # broken `flutter//flutter_gpu.zip` URL and a failed bootstrap. Re-clone
+          # until the engine version is present, precache serially before melos'
+          # concurrent pub gets, and retry to absorb transient failures.
+          export PATH="$RUNNER_TEMP/flutter/bin:$HOME/.pub-cache/bin:$PATH"
+          ok=0
+          for attempt in 1 2 3; do
+            rm -rf "$RUNNER_TEMP/flutter"
+            git clone --depth 1 -b 3.32.8 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter" \
+              || { echo "::warning::clone failed (attempt $attempt)"; sleep 10; continue; }
+            if [ ! -s "$RUNNER_TEMP/flutter/bin/internal/engine.version" ]; then
+              echo "::warning::empty engine.version (attempt $attempt); re-cloning"; sleep 10; continue
+            fi
+            flutter --version \
+              && flutter precache \
+              && dart pub global activate melos \
+              && melos bootstrap \
+              && { ok=1; break; }
+            echo "::warning::setup/bootstrap failed (attempt $attempt); retrying"; sleep 10
+          done
+          [ "$ok" = 1 ] || { echo "Flutter setup/bootstrap failed after retries"; exit 1; }
           echo "$RUNNER_TEMP/flutter/bin" >> "$GITHUB_PATH"
           echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
-
-      - name: 🔧 Setup Melos
-        run: |
-          flutter --version
-          flutter precache
-          dart pub global activate melos
-
-      - name: 📦 Bootstrap Dependencies
-        run: melos bootstrap
 
       - name: 🏗️ Generate Code
         run: melos run generate
@@ -137,20 +161,32 @@ jobs:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
 
-      - name: 🐦 Setup Flutter (git)
+      - name: 🐦 Setup Flutter & Bootstrap
         run: |
-          git clone --depth 1 -b 3.32.8 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter"
+          # These self-hosted runners intermittently produce an incomplete
+          # Flutter checkout (empty bin/internal/engine.version), which yields a
+          # broken `flutter//flutter_gpu.zip` URL and a failed bootstrap. Re-clone
+          # until the engine version is present, precache serially before melos'
+          # concurrent pub gets, and retry to absorb transient failures.
+          export PATH="$RUNNER_TEMP/flutter/bin:$HOME/.pub-cache/bin:$PATH"
+          ok=0
+          for attempt in 1 2 3; do
+            rm -rf "$RUNNER_TEMP/flutter"
+            git clone --depth 1 -b 3.32.8 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter" \
+              || { echo "::warning::clone failed (attempt $attempt)"; sleep 10; continue; }
+            if [ ! -s "$RUNNER_TEMP/flutter/bin/internal/engine.version" ]; then
+              echo "::warning::empty engine.version (attempt $attempt); re-cloning"; sleep 10; continue
+            fi
+            flutter --version \
+              && flutter precache \
+              && dart pub global activate melos \
+              && melos bootstrap \
+              && { ok=1; break; }
+            echo "::warning::setup/bootstrap failed (attempt $attempt); retrying"; sleep 10
+          done
+          [ "$ok" = 1 ] || { echo "Flutter setup/bootstrap failed after retries"; exit 1; }
           echo "$RUNNER_TEMP/flutter/bin" >> "$GITHUB_PATH"
           echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
-
-      - name: 🔧 Setup Melos
-        run: |
-          flutter --version
-          flutter precache
-          dart pub global activate melos
-
-      - name: 📦 Bootstrap Dependencies
-        run: melos bootstrap
 
       - name: 🏗️ Generate Code
         run: melos run generate
@@ -165,20 +201,32 @@ jobs:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
 
-      - name: 🐦 Setup Flutter (git)
+      - name: 🐦 Setup Flutter & Bootstrap
         run: |
-          git clone --depth 1 -b 3.32.8 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter"
+          # These self-hosted runners intermittently produce an incomplete
+          # Flutter checkout (empty bin/internal/engine.version), which yields a
+          # broken `flutter//flutter_gpu.zip` URL and a failed bootstrap. Re-clone
+          # until the engine version is present, precache serially before melos'
+          # concurrent pub gets, and retry to absorb transient failures.
+          export PATH="$RUNNER_TEMP/flutter/bin:$HOME/.pub-cache/bin:$PATH"
+          ok=0
+          for attempt in 1 2 3; do
+            rm -rf "$RUNNER_TEMP/flutter"
+            git clone --depth 1 -b 3.32.8 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter" \
+              || { echo "::warning::clone failed (attempt $attempt)"; sleep 10; continue; }
+            if [ ! -s "$RUNNER_TEMP/flutter/bin/internal/engine.version" ]; then
+              echo "::warning::empty engine.version (attempt $attempt); re-cloning"; sleep 10; continue
+            fi
+            flutter --version \
+              && flutter precache \
+              && dart pub global activate melos \
+              && melos bootstrap \
+              && { ok=1; break; }
+            echo "::warning::setup/bootstrap failed (attempt $attempt); retrying"; sleep 10
+          done
+          [ "$ok" = 1 ] || { echo "Flutter setup/bootstrap failed after retries"; exit 1; }
           echo "$RUNNER_TEMP/flutter/bin" >> "$GITHUB_PATH"
           echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
-
-      - name: 🔧 Setup Melos
-        run: |
-          flutter --version
-          flutter precache
-          dart pub global activate melos
-
-      - name: 📦 Bootstrap Dependencies
-        run: melos bootstrap
 
       - name: 🔒 Security Audit
         run: |
@@ -196,20 +244,32 @@ jobs:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
 
-      - name: 🐦 Setup Flutter (git)
+      - name: 🐦 Setup Flutter & Bootstrap
         run: |
-          git clone --depth 1 -b 3.32.8 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter"
+          # These self-hosted runners intermittently produce an incomplete
+          # Flutter checkout (empty bin/internal/engine.version), which yields a
+          # broken `flutter//flutter_gpu.zip` URL and a failed bootstrap. Re-clone
+          # until the engine version is present, precache serially before melos'
+          # concurrent pub gets, and retry to absorb transient failures.
+          export PATH="$RUNNER_TEMP/flutter/bin:$HOME/.pub-cache/bin:$PATH"
+          ok=0
+          for attempt in 1 2 3; do
+            rm -rf "$RUNNER_TEMP/flutter"
+            git clone --depth 1 -b 3.32.8 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter" \
+              || { echo "::warning::clone failed (attempt $attempt)"; sleep 10; continue; }
+            if [ ! -s "$RUNNER_TEMP/flutter/bin/internal/engine.version" ]; then
+              echo "::warning::empty engine.version (attempt $attempt); re-cloning"; sleep 10; continue
+            fi
+            flutter --version \
+              && flutter precache \
+              && dart pub global activate melos \
+              && melos bootstrap \
+              && { ok=1; break; }
+            echo "::warning::setup/bootstrap failed (attempt $attempt); retrying"; sleep 10
+          done
+          [ "$ok" = 1 ] || { echo "Flutter setup/bootstrap failed after retries"; exit 1; }
           echo "$RUNNER_TEMP/flutter/bin" >> "$GITHUB_PATH"
           echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
-
-      - name: 🔧 Setup Melos
-        run: |
-          flutter --version
-          flutter precache
-          dart pub global activate melos
-
-      - name: 📦 Bootstrap Dependencies
-        run: melos bootstrap
 
       - name: 📖 Generate Documentation
         run: |


### PR DESCRIPTION
## Problem

Self-hosted jobs still intermittently fail bootstrap (even post-#14):

```
Failed to download .../flutter_infra_release/flutter//flutter_gpu.zip
```

The empty `flutter//` segment means `bin/internal/engine.version` came out **empty** — an *incomplete* Flutter checkout on the runner. Locally, a fresh `git clone --depth 1 -b 3.32.8` resolves the engine version correctly and `flutter precache` succeeds (rc=0), so this is **environmental/transient**, not a clone-depth flaw. It still flaked the post-merge push run on `main` and the merge queue.

## Fix

Collapse Setup Flutter + Setup Melos + Bootstrap into one resilient step for the self-hosted jobs that:

1. **Re-clones** Flutter until `bin/internal/engine.version` is non-empty (guards the actual failure mode).
2. **Precaches serially** before melos' concurrent `pub get`s.
3. **Retries up to 3×** to absorb transient clone/download failures, then exports PATH for the remaining steps.

The GitHub-hosted `test` matrix is unchanged (subosito + plain bootstrap — never flaked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)