### PR TITLE
ci: cap flutter test concurrency on self-hosted coverage/perf jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,10 @@ jobs:
         # All tests live in flutter_example; `flutter test --coverage` writes
         # apps/flutter_example/coverage/lcov.info. (The old format_coverage step
         # relied on the removed `.packages` file and had no coverage input.)
-        run: melos exec --scope="flutter_example" -- flutter test --coverage
+        # --concurrency=2: the self-hosted runners exhaust threads
+        # (pthread_create failed) under coverage instrumentation at the default
+        # concurrency. Lower it for a reliable (if slower) coverage run.
+        run: melos exec --scope="flutter_example" -- flutter test --coverage --concurrency=2
 
       - name: 📤 Upload Coverage
         uses: codecov/codecov-action@v3
@@ -192,7 +195,7 @@ jobs:
         run: melos run generate
 
       - name: ⚡ Performance Benchmarks
-        run: melos exec --scope="flutter_example" -- flutter test --dart-define=PERFORMANCE_TEST=true
+        run: melos exec --scope="flutter_example" -- flutter test --dart-define=PERFORMANCE_TEST=true --concurrency=2
 
   # Security scanning
   security:


### PR DESCRIPTION
## Problem

The `coverage` job intermittently fails:

```
Failed to load ".../test/features/iterable_support_test.dart": pthread_create failed
500 tests passed, 1 failed, 9 skipped.
```

`pthread_create failed` = the self-hosted runner ran out of threads. `flutter test --coverage` adds coverage isolates/threads on top of the default (CPU-count) test concurrency, exceeding the runner's limit.

## Fix

Pass `--concurrency=2` to the `coverage` and `performance` runs (both self-hosted). The GitHub-hosted `test` matrix is unchanged — it has the headroom and never showed this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)