### PR TITLE
docs: refresh public-facing docs for the 4.0 line

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,21 @@ int age = user.profile.age;  // ✅ Type-safe nested access
 
 ---
 
-## 🎉 New in Version 3.0!
+## 🎉 New in Version 4.0
 
-**The most stable and feature-complete release yet** - over 90% of planned features complete!
+Building on 3.0's performance foundation, **4.0 expands type coverage and ergonomics** on top of a fully reworked code generator.
 
-### Performance Improvements
+> ℹ️ 4.0 is currently a **pre-release** (`4.0.0-dev`). The current stable line is 3.x.
+
+### New in 4.0
+- ✅ **Enum support** - `@JsonValue` with both string *and* numeric values, enums in `orderBy()`, and default-value generation
+- ✅ **Automatic nested-class imports** - filter, patch, aggregate, and `orderBy` selectors for nested types need no manual imports
+- ✅ **Stronger nullable handling** - nullable `Map` fields, and nested `fromJson` factories that accept nullable input no longer crash when a field is missing
+- ✅ **Server timestamps on insert** - not only on updates, and honored inside batches
+- ✅ **Batch & transaction patch builders** - atomic patch operations in `runBatch` / `runTransaction`
+- ✅ **Reworked code generator** - cleaner filter/patch/aggregate/orderBy builders and converters on a unified `FieldPath` model
+
+### Performance (established in 3.0, retained in 4.0)
 
 | Metric | Improvement | Impact |
 |--------|-------------|--------|
@@ -54,12 +64,11 @@ int age = user.profile.age;  // ✅ Type-safe nested access
 | **Compilation Speed** | **<1 second** | Complex schemas compile instantly |
 | **Runtime Overhead** | **Zero** | All magic at compile time |
 
-### New Features & Capabilities
+### Carried over from 3.0
 - ✅ **Full generic model support** - Generic classes with type-safe patch operations
 - ✅ **Complete JsonKey & JsonConverter support** - Full serialization control
 - ✅ **Automatic conversion fallbacks** - JsonConverter optional in most cases
 - ✅ **Enhanced map operations** - Comprehensive map field support with atomic ops
-- ✅ **100+ new test cases** - Rigorous testing for production stability
 
 ---
 
@@ -398,7 +407,7 @@ await db.users.insert(User(
 
 ## 📊 Performance & Technical Excellence
 
-### Optimized Code Generation (v3.0)
+### Optimized Code Generation
 
 | Metric | Value | Benefit |
 |--------|-------|---------|
@@ -453,19 +462,20 @@ void main() {
 
 ## 🗺️ Roadmap
 
-**✅ Completed (v3.0)**
+**✅ Completed (3.0 → 4.0)**
 - [x] Full generic model support
 - [x] Complete JsonKey & JsonConverter support
-- [x] 20% runtime performance improvement
-- [x] 15% reduction in generated code
-- [x] 100+ new test cases
+- [x] 20% runtime performance improvement & 15% smaller generated code
+- [x] Enum support — string & numeric `@JsonValue`, `orderBy`, defaults *(4.0)*
+- [x] Automatic nested-class imports *(4.0)*
+- [x] Batch & transaction patch builders *(4.0)*
+- [x] Server timestamps on insert *(4.0)*
 - [x] Production-ready stability
 
 **🚀 Next**
-- [ ] Batch collection operations
-- [ ] Map field filtering, ordering, and aggregation
+- [ ] [Firestore Pipelines support](https://github.com/SylphxAI/firestore_odm/issues/6)
+- [ ] Full map field filtering, ordering, and aggregation
 - [ ] Nested map support
-- [ ] Performance monitoring
 - [ ] Enhanced documentation
 
 ---

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -67,6 +67,13 @@ export default defineConfig({
             { text: 'Aggregations', link: '/guide/aggregations' },
             { text: 'Subcollections', link: '/guide/subcollections' },
           ]
+        },
+        {
+          text: 'Release Notes',
+          items: [
+            { text: 'Version 4.0', link: '/guide/version-4.0-release-notes' },
+            { text: 'Version 3.0', link: '/guide/version-3.0-release-notes' },
+          ]
         }
       ]
     },

--- a/docs/guide/version-4.0-release-notes.md
+++ b/docs/guide/version-4.0-release-notes.md
@@ -1,0 +1,107 @@
+# Version 4.0 Release Notes
+
+Firestore ODM 4.0 builds on 3.0's performance foundation with a **fully reworked
+code generator**, broader type coverage, and ergonomic wins — while keeping the
+schema, model, query, and update API you already write unchanged.
+
+::: info Pre-release
+4.0 is currently published as a pre-release (`4.0.0-dev`). The current stable
+line is 3.x. There are no intentional breaking changes to the public API;
+4.0 is primarily new capabilities plus a large internal refactor.
+:::
+
+## 🎉 What's New in 4.0
+
+### 🔢 Enum support
+
+Enums are now first-class. `@JsonValue` is honored for **both string and
+numeric** values, enums work in `orderBy()`, and defaults are generated.
+
+```dart
+@JsonEnum()
+enum AccountType {
+  @JsonValue('free') free,
+  @JsonValue('pro') pro,
+  @JsonValue('enterprise') enterprise,
+}
+
+// Filter and order by enum fields, fully type-safe
+final pros = await db.users
+  .where(($) => $.accountType(isEqualTo: AccountType.pro))
+  .orderBy(($) => $.accountType())
+  .get();
+```
+
+### 🧩 Automatic nested-class imports
+
+Filter, patch, aggregate, and `orderBy` selectors for **nested types** no longer
+require you to manually import the nested classes — the generator wires up the
+imports for you.
+
+```dart
+// `Profile` is nested inside `User`; no manual import of Profile needed
+await db.users('jane').patch(($) => [
+  $.profile.followers.increment(1),
+  $.profile.bio.set('Updated bio'),
+]);
+```
+
+### 🛡️ Stronger nullable & type handling
+
+- Nullable `Map` fields are supported in updates and filters.
+- Nested `fromJson` factories that accept a **nullable** map (e.g.
+  `Address.fromJson(Map<String, Object?>? json)`) are now deserialized with a
+  nullable cast, so reading a document where the field is absent no longer
+  crashes with `type 'Null' is not a subtype of type 'Map<String, Object?>'`
+  ([#5](https://github.com/SylphxAI/firestore_odm/issues/5)).
+- Non-nullable enum fields resolve correctly (no spurious null assertions).
+
+### ⏱️ Server timestamps on insert
+
+`FirestoreODM.serverTimestamp` is now applied on **insert** operations (not only
+updates) and is honored inside batches.
+
+### 🧱 Batch & transaction patch builders
+
+Atomic patch operations are available inside `runBatch` and `runTransaction`,
+plus a `getBatchCollection()` convenience.
+
+### 🏗️ Reworked code generator
+
+The filter, patch, aggregate, and `orderBy` builders and the converters were
+rebuilt on a unified `FieldPath` model, with a consolidated `TypeDefinition`
+type. This is internal, but it produces cleaner generated code and a more
+consistent foundation for future features.
+
+## ⚙️ Performance
+
+The performance characteristics established in 3.0 are retained:
+
+| Metric | Value |
+|--------|-------|
+| Runtime performance | ~20% faster than baseline |
+| Generated code size | ~15% smaller |
+| Compilation | Sub-second for complex schemas |
+| Runtime overhead | Zero (all work at compile time) |
+
+## ⬆️ Upgrading from 3.x
+
+The public API is unchanged for typical usage (schema definition, models,
+queries, `patch`/`modify`, transactions, batches). Upgrade by bumping the
+dependency and re-running the generator:
+
+```bash
+dart pub add firestore_odm:^4.0.0-dev
+dart pub add dev:firestore_odm_builder:^4.0.0-dev
+dart run build_runner build --delete-conflicting-outputs
+```
+
+If you depended on internal-only classes (e.g. the removed `BatchField` /
+`BatchConfiguration` helpers, or referenced the internal `Node2` type), prefer
+the public collection/document/patch-builder APIs instead.
+
+## 🔭 What's next
+
+- [Firestore Pipelines support](https://github.com/SylphxAI/firestore_odm/issues/6)
+- Full map field filtering, ordering, and aggregation
+- Nested map support

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,11 +14,13 @@ hero:
       link: https://github.com/SylphxAI/firestore_odm
 
 features:
-  - title: "⚡ Lightning Fast Code Generation (3.0 Enhanced)"
+  - title: "⚡ Lightning Fast Code Generation"
     details: Inline-first optimized code using callables and Dart extensions. 20% faster runtime, 15% less generated code.
-  - title: "🪶 Minimal Generated Code"
-    details: Smart code generation produces compact, efficient output without bloating your project size. Sub-second compilation.
-  - title: "🧬 Full Generic Support (New in 3.0)"
+  - title: "🔢 Enum Support (New in 4.0)"
+    details: "@JsonValue with string and numeric values, enums in orderBy, and default-value generation."
+  - title: "🧩 Automatic Nested Imports (New in 4.0)"
+    details: Filter, patch, aggregate, and orderBy selectors for nested types need no manual imports.
+  - title: "🧬 Full Generic Support"
     details: Complete generic model support with type-safe patch operations that respect generic constraints.
   - title: "🛡️ Runtime Error Prevention"
     details: Catch mistakes at compile-time, not in production. Say goodbye to string-based field names.
@@ -26,8 +28,8 @@ features:
     details: Write complex filters that read like natural language and are fully type-safe.
   - title: "🧠 Smart Pagination"
     details: Revolutionary pagination with zero inconsistency risk, thanks to our Smart Builder.
-  - title: "🔄 Powerful Updates (3.0 Improved)"
-    details: Two powerful update strategies (patch, modify) with enhanced atomic operation detection.
-  - title: "🧩 Flexible Modeling (3.0 Enhanced)"
+  - title: "🔄 Powerful Updates"
+    details: Two powerful update strategies (patch, modify) with atomic operation detection, plus batch & transaction patch builders.
+  - title: "🧩 Flexible Modeling"
     details: Supports freezed, plain Dart classes, fast_immutable_collections, JsonKey & JsonConverter.
 ---


### PR DESCRIPTION
Updates the public-facing documentation ahead of the `4.0.0-dev.3` release (which ships the #5 fix).

## Changes
- **README** (SSOT, symlinked into all 3 packages): replaces the "New in Version 3.0" section with **New in 4.0** — enum support, automatic nested-class imports, stronger nullable handling (incl. #5), server timestamps on insert, batch/transaction patch builders. The 3.0 performance numbers are kept, reframed as the retained baseline. Roadmap refreshed (links Pipelines #6).
- **docs/index.md**: feature cards updated; enum + nested-import highlighted as 4.0.
- **docs/guide/version-4.0-release-notes.md**: new release notes with code examples and an "Upgrading from 3.x" section (no breaking public-API changes).
- **vitepress sidebar**: adds a Release Notes section (4.0 + 3.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)