### PR TITLE
chore(release): 4.0.0-dev.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,10 +142,10 @@ jobs:
         # All tests live in flutter_example; `flutter test --coverage` writes
         # apps/flutter_example/coverage/lcov.info. (The old format_coverage step
         # relied on the removed `.packages` file and had no coverage input.)
-        # --concurrency=2: the self-hosted runners exhaust threads
+        # --concurrency=1: the self-hosted runners exhaust threads
         # (pthread_create failed) under coverage instrumentation at the default
         # concurrency. Lower it for a reliable (if slower) coverage run.
-        run: melos exec --scope="flutter_example" -- flutter test --coverage --concurrency=2
+        run: melos exec --scope="flutter_example" -- flutter test --coverage --concurrency=1
 
       - name: 📤 Upload Coverage
         uses: codecov/codecov-action@v3
@@ -195,7 +195,7 @@ jobs:
         run: melos run generate
 
       - name: ⚡ Performance Benchmarks
-        run: melos exec --scope="flutter_example" -- flutter test --dart-define=PERFORMANCE_TEST=true --concurrency=2
+        run: melos exec --scope="flutter_example" -- flutter test --dart-define=PERFORMANCE_TEST=true --concurrency=1
 
   # Security scanning
   security:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,17 +25,31 @@ jobs:
           fetch-depth: 0  # Need full git history for conventional commits
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 🐦 Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-          cache: true
-
-      - name: 🔧 Setup Melos
-        run: dart pub global activate melos
-
-      - name: 📦 Bootstrap
-        run: melos bootstrap
+      - name: 🐦 Setup Flutter & Bootstrap
+        run: |
+          # Mirror ci.yml: pin Flutter 3.32.8 (Dart 3.8.1) — newer stable breaks
+          # `melos bootstrap` against analyzer ^7.4.5 — and install via a
+          # retry-guarded git clone (subosito's archive install intermittently
+          # leaves an empty engine version on these self-hosted runners).
+          export PATH="$RUNNER_TEMP/flutter/bin:$HOME/.pub-cache/bin:$PATH"
+          ok=0
+          for attempt in 1 2 3; do
+            rm -rf "$RUNNER_TEMP/flutter"
+            git clone --depth 1 -b 3.32.8 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter" \
+              || { echo "::warning::clone failed (attempt $attempt)"; sleep 10; continue; }
+            if [ ! -s "$RUNNER_TEMP/flutter/bin/internal/engine.version" ]; then
+              echo "::warning::empty engine.version (attempt $attempt); re-cloning"; sleep 10; continue
+            fi
+            flutter --version \
+              && flutter precache \
+              && dart pub global activate melos \
+              && melos bootstrap \
+              && { ok=1; break; }
+            echo "::warning::setup/bootstrap failed (attempt $attempt); retrying"; sleep 10
+          done
+          [ "$ok" = 1 ] || { echo "Flutter setup/bootstrap failed after retries"; exit 1; }
+          echo "$RUNNER_TEMP/flutter/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
 
       - name: 📋 Dry Run Publish (annotation only)
         run: |
@@ -113,7 +127,9 @@ jobs:
           fi
 
       - name: 📊 Create Release
-        if: ${{ (inputs.run_publish || startsWith(github.ref, 'refs/tags/')) && success() }}
+        # Only on tag pushes — workflow_dispatch has github.ref_name=main (and a
+        # `main` tag already exists), which would make a bogus release.
+        if: ${{ startsWith(github.ref, 'refs/tags/') && success() }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/firestore_odm/CHANGELOG.md
+++ b/packages/firestore_odm/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0-dev.3
+
+- Bump to match firestore_odm_builder 4.0.0-dev.3 (nested `fromJson` nullable-cast fix, #5). No runtime API changes in this package.
+
 ## 4.0.0-dev.2
 
 - Fix nullable Map type constraint in DartMapFieldUpdate

--- a/packages/firestore_odm/pubspec.yaml
+++ b/packages/firestore_odm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firestore_odm
 description: Type-safe Firestore ODM with code generation support. Generate type-safe Firestore operations with annotations.
-version: 4.0.0-dev.2
+version: 4.0.0-dev.3
 homepage: https://github.com/SylphxAI/firestore_odm
 repository: https://github.com/SylphxAI/firestore_odm
 issue_tracker: https://github.com/SylphxAI/firestore_odm/issues

--- a/packages/firestore_odm_annotation/CHANGELOG.md
+++ b/packages/firestore_odm_annotation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0-dev.3
+
+- Bump version to match other packages.
+
 ## 4.0.0-dev.2
 
 - Fix nullable type handling in code generation

--- a/packages/firestore_odm_annotation/pubspec.yaml
+++ b/packages/firestore_odm_annotation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firestore_odm_annotation
 description: Pure annotations for Firestore ODM code generation. Provides the core annotations used to generate type-safe Firestore ODM code.
-version: 4.0.0-dev.2
+version: 4.0.0-dev.3
 homepage: https://github.com/SylphxAI/firestore_odm
 repository: https://github.com/SylphxAI/firestore_odm
 issue_tracker: https://github.com/SylphxAI/firestore_odm/issues

--- a/packages/firestore_odm_builder/CHANGELOG.md
+++ b/packages/firestore_odm_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0-dev.3
+
+- Fix nested `fromJson` factories that accept a nullable map generating a non-nullable cast, which crashed (`type 'Null' is not a subtype of type 'Map<String, Object?>'`) when the field was absent from a document (closes #5)
+
 ## 4.0.0-dev.2
 
 - Fix enum null assertion for non-nullable enum types

--- a/packages/firestore_odm_builder/pubspec.yaml
+++ b/packages/firestore_odm_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firestore_odm_builder
 description: Code generator for Firestore ODM annotations. Generates type-safe Firestore operations from annotated classes.
-version: 4.0.0-dev.2
+version: 4.0.0-dev.3
 homepage: https://github.com/SylphxAI/firestore_odm
 repository: https://github.com/SylphxAI/firestore_odm
 issue_tracker: https://github.com/SylphxAI/firestore_odm/issues


### PR DESCRIPTION
Cuts **4.0.0-dev.3**, shipping the #5 fix (nested `fromJson` nullable-cast crash).

## Changes
- Bump all three packages `4.0.0-dev.2` → `4.0.0-dev.3` + CHANGELOG entries.
- Make the **release workflow runnable**: it previously used `channel: stable` (drifted to Dart 3.12, breaking `melos bootstrap` against `analyzer ^7.4.5`) and would have published the already-existing `dev.2`. Now it uses the same retry-guarded git-clone of pinned Flutter 3.32.8 as `ci.yml`, and only creates a GitHub Release on tag pushes (workflow_dispatch has `github.ref_name=main`).

## Publish plan
After merge: run the Release workflow as a **dry-run** first (`run_publish=false`) to confirm it bootstraps + dry-run-publishes, then re-run with `run_publish=true` to publish `dev.3` to pub.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)