### PR TITLE
refactor(builder): migrate to analyzer 8+ new element model; unpin Flutter (4.0.0-dev.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,10 @@ on:
   merge_group:
     types: [checks_requested]
 
-# Flutter is pinned to 3.32.8 (Dart 3.8.1): newer stable (Dart >=3.12) pulls
-# test/analyzer >=8 and breaks `melos bootstrap` against this repo's
-# `analyzer ^7.4.5`. Revisit when the analyzer 8.x upgrade lands.
+# Flutter is pinned to the current stable, 3.44.2 (Dart 3.12.2), deliberately —
+# bump it on purpose, don't float `channel: stable` (silent drift previously
+# broke CI). The builder needs analyzer >=9 (Dart >=3.9), so 3.32.x no longer
+# works.
 #
 # Self-hosted jobs install Flutter via a shallow git clone instead of
 # subosito/flutter-action: the archive install intermittently produced a Flutter
@@ -39,7 +40,7 @@ jobs:
           ok=0
           for attempt in 1 2 3; do
             rm -rf "$RUNNER_TEMP/flutter"
-            git clone --depth 1 -b 3.32.8 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter" \
+            git clone --depth 1 -b 3.44.2 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter" \
               || { echo "::warning::clone failed (attempt $attempt)"; sleep 10; continue; }
             if [ ! -s "$RUNNER_TEMP/flutter/bin/internal/engine.version" ]; then
               echo "::warning::empty engine.version (attempt $attempt); re-cloning"; sleep 10; continue
@@ -70,9 +71,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        # Pinned to a project-compatible version (Dart 3.8.x). The stable/beta
-        # channel matrix broke once stable moved to Dart >=3.12 (analyzer 8.x).
-        flutter-version: ['3.32.8']
+        # Pinned to current stable (bump deliberately, don't float a channel).
+        flutter-version: ['3.44.2']
       fail-fast: false
 
     steps:
@@ -119,7 +119,7 @@ jobs:
           ok=0
           for attempt in 1 2 3; do
             rm -rf "$RUNNER_TEMP/flutter"
-            git clone --depth 1 -b 3.32.8 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter" \
+            git clone --depth 1 -b 3.44.2 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter" \
               || { echo "::warning::clone failed (attempt $attempt)"; sleep 10; continue; }
             if [ ! -s "$RUNNER_TEMP/flutter/bin/internal/engine.version" ]; then
               echo "::warning::empty engine.version (attempt $attempt); re-cloning"; sleep 10; continue
@@ -175,7 +175,7 @@ jobs:
           ok=0
           for attempt in 1 2 3; do
             rm -rf "$RUNNER_TEMP/flutter"
-            git clone --depth 1 -b 3.32.8 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter" \
+            git clone --depth 1 -b 3.44.2 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter" \
               || { echo "::warning::clone failed (attempt $attempt)"; sleep 10; continue; }
             if [ ! -s "$RUNNER_TEMP/flutter/bin/internal/engine.version" ]; then
               echo "::warning::empty engine.version (attempt $attempt); re-cloning"; sleep 10; continue
@@ -215,7 +215,7 @@ jobs:
           ok=0
           for attempt in 1 2 3; do
             rm -rf "$RUNNER_TEMP/flutter"
-            git clone --depth 1 -b 3.32.8 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter" \
+            git clone --depth 1 -b 3.44.2 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter" \
               || { echo "::warning::clone failed (attempt $attempt)"; sleep 10; continue; }
             if [ ! -s "$RUNNER_TEMP/flutter/bin/internal/engine.version" ]; then
               echo "::warning::empty engine.version (attempt $attempt); re-cloning"; sleep 10; continue
@@ -258,7 +258,7 @@ jobs:
           ok=0
           for attempt in 1 2 3; do
             rm -rf "$RUNNER_TEMP/flutter"
-            git clone --depth 1 -b 3.32.8 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter" \
+            git clone --depth 1 -b 3.44.2 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter" \
               || { echo "::warning::clone failed (attempt $attempt)"; sleep 10; continue; }
             if [ ! -s "$RUNNER_TEMP/flutter/bin/internal/engine.version" ]; then
               echo "::warning::empty engine.version (attempt $attempt); re-cloning"; sleep 10; continue

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,15 +27,15 @@ jobs:
 
       - name: 🐦 Setup Flutter & Bootstrap
         run: |
-          # Mirror ci.yml: pin Flutter 3.32.8 (Dart 3.8.1) — newer stable breaks
-          # `melos bootstrap` against analyzer ^7.4.5 — and install via a
-          # retry-guarded git clone (subosito's archive install intermittently
-          # leaves an empty engine version on these self-hosted runners).
+          # Mirror ci.yml: pin Flutter to current stable 3.44.2 (bump
+          # deliberately), installed via a retry-guarded git clone (subosito's
+          # archive install intermittently leaves an empty engine version on
+          # these self-hosted runners).
           export PATH="$RUNNER_TEMP/flutter/bin:$HOME/.pub-cache/bin:$PATH"
           ok=0
           for attempt in 1 2 3; do
             rm -rf "$RUNNER_TEMP/flutter"
-            git clone --depth 1 -b 3.32.8 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter" \
+            git clone --depth 1 -b 3.44.2 https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter" \
               || { echo "::warning::clone failed (attempt $attempt)"; sleep 10; continue; }
             if [ ! -s "$RUNNER_TEMP/flutter/bin/internal/engine.version" ]; then
               echo "::warning::empty engine.version (attempt $attempt); re-cloning"; sleep 10; continue

--- a/packages/firestore_odm/CHANGELOG.md
+++ b/packages/firestore_odm/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0-dev.4
+
+- Bump to match firestore_odm_builder 4.0.0-dev.4 (analyzer 8+ migration). No runtime API changes in this package.
+
 ## 4.0.0-dev.3
 
 - Bump to match firestore_odm_builder 4.0.0-dev.3 (nested `fromJson` nullable-cast fix, #5). No runtime API changes in this package.

--- a/packages/firestore_odm/pubspec.yaml
+++ b/packages/firestore_odm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firestore_odm
 description: Type-safe Firestore ODM with code generation support. Generate type-safe Firestore operations with annotations.
-version: 4.0.0-dev.3
+version: 4.0.0-dev.4
 homepage: https://github.com/SylphxAI/firestore_odm
 repository: https://github.com/SylphxAI/firestore_odm
 issue_tracker: https://github.com/SylphxAI/firestore_odm/issues

--- a/packages/firestore_odm_annotation/CHANGELOG.md
+++ b/packages/firestore_odm_annotation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0-dev.4
+
+- Bump version to match other packages.
+
 ## 4.0.0-dev.3
 
 - Bump version to match other packages.

--- a/packages/firestore_odm_annotation/pubspec.yaml
+++ b/packages/firestore_odm_annotation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firestore_odm_annotation
 description: Pure annotations for Firestore ODM code generation. Provides the core annotations used to generate type-safe Firestore ODM code.
-version: 4.0.0-dev.3
+version: 4.0.0-dev.4
 homepage: https://github.com/SylphxAI/firestore_odm
 repository: https://github.com/SylphxAI/firestore_odm
 issue_tracker: https://github.com/SylphxAI/firestore_odm/issues

--- a/packages/firestore_odm_builder/CHANGELOG.md
+++ b/packages/firestore_odm_builder/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.0-dev.4
+
+- Migrate to the analyzer 8+ "new element model": `analyzer` `>=9.0.0 <14.0.0` (was `^7.4.5`), `source_gen` `^4.2.3`, `build` `^4.0.0`. Replaces removed/renamed APIs (`element3`→`element`, `name3`→`name`, `typeParameters2`→`typeParameters`, `lookUpConstructor2`/`lookUpMethod3`→`lookUp*`, `TypeChecker.fromRuntime`→`typeNamed`, `metadata`→`metadata.annotations`, unnamed constructor name `''`→`'new'`).
+- **Min SDK raised to Dart `^3.9.0`** (required by analyzer 8+). Lets the package build on current Flutter stable.
+
 ## 4.0.0-dev.3
 
 - Fix nested `fromJson` factories that accept a nullable map generating a non-nullable cast, which crashed (`type 'Null' is not a subtype of type 'Map<String, Object?>'`) when the field was absent from a document (closes #5)

--- a/packages/firestore_odm_builder/lib/src/generators/aggregate_generator.dart
+++ b/packages/firestore_odm_builder/lib/src/generators/aggregate_generator.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:firestore_odm_builder/src/utils/reference_utils.dart';
@@ -21,12 +21,8 @@ class AggregateGenerator {
     };
     if (field.type is TypeParameterType) {
       return TypeDefinition(
-        type: TypeReference(
-          (b) => b..symbol = '\$${field.type.element3!.name3}',
-        ),
-        instance: refer(
-          '_builderFunc${field.type.element3!.name3!.camelCase()}',
-        ),
+        type: TypeReference((b) => b..symbol = '\$${field.type.element!.name}'),
+        instance: refer('_builderFunc${field.type.element!.name!.camelCase()}'),
         namedArguments: args,
       );
     }
@@ -35,7 +31,7 @@ class AggregateGenerator {
       return TypeDefinition(
         type: TypeReference(
           (b) => b
-            ..symbol = '${field.type.element3!.name3}AggregateFieldSelector'
+            ..symbol = '${field.type.element!.name}AggregateFieldSelector'
             ..types.addAll(field.type.typeArguments.map((e) => e.reference)),
         ),
         namedArguments: args,
@@ -79,12 +75,12 @@ class AggregateGenerator {
     return specs;
   }
 
-  static Set<TypeParameterElement2> computeNeededBuilders({
+  static Set<TypeParameterElement> computeNeededBuilders({
     required InterfaceType type,
   }) {
     final map = Map.fromIterables(
       type.typeArguments,
-      type.element3.typeParameters2,
+      type.element.typeParameters,
     );
     final fields = getFields(type);
     final fieldTypes = fields.values.map((field) => field.type).toSet();
@@ -92,19 +88,19 @@ class AggregateGenerator {
   }
 
   static Class generateAggregateRootClass(InterfaceType type) {
-    final className = type.element3.name3;
-    final builders = computeNeededBuilders(type: type.element3.thisType);
+    final className = type.element.name;
+    final builders = computeNeededBuilders(type: type.element.thisType);
     return Class(
       (b) => b
         ..name = '${className}AggregateBuilderRoot'
         ..types.addAll(
-          type.element3.typeParameters2.expand(
+          type.element.typeParameters.expand(
             (t) => [
               t.reference,
               if (builders.contains(t))
                 TypeReference(
                   (b) => b
-                    ..symbol = '\$${t.name3}'
+                    ..symbol = '\$${t.name}'
                     ..bound = refer('AggregateFieldNode'),
                 ),
             ],
@@ -114,11 +110,11 @@ class AggregateGenerator {
           (b) => b
             ..symbol = '${className}AggregateFieldSelector'
             ..types.addAll(
-              type.element3.typeParameters2.expand(
+              type.element.typeParameters.expand(
                 (t) => [
                   t.reference,
                   if (builders.contains(t))
-                    TypeReference((b) => b..symbol = '\$${t.name3}'),
+                    TypeReference((b) => b..symbol = '\$${t.name}'),
                 ],
               ),
             ),
@@ -137,11 +133,11 @@ class AggregateGenerator {
                     ..named = true,
                 ),
                 for (final typeParam in computeNeededBuilders(
-                  type: type.element3.thisType,
+                  type: type.element.thisType,
                 ))
                   Parameter(
                     (b) => b
-                      ..name = 'builderFunc${typeParam.name3!.camelCase()}'
+                      ..name = 'builderFunc${typeParam.name!.camelCase()}'
                       ..toSuper = true
                       ..named = true
                       ..required = true,
@@ -160,7 +156,7 @@ class AggregateGenerator {
   }
 
   static Class generateAggregateClass(InterfaceType type) {
-    final className = type.element3.name3;
+    final className = type.element.name;
 
     final builders = computeNeededBuilders(type: type);
 
@@ -180,13 +176,13 @@ class AggregateGenerator {
       (b) => b
         ..name = '${className}AggregateFieldSelector'
         ..types.addAll(
-          type.element3.typeParameters2.expand(
+          type.element.typeParameters.expand(
             (t) => [
               t.reference,
               if (builders.contains(t))
                 TypeReference(
                   (b) => b
-                    ..symbol = '\$${t.name3}'
+                    ..symbol = '\$${t.name}'
                     ..bound = refer('AggregateFieldNode'),
                 ),
             ],
@@ -209,11 +205,11 @@ class AggregateGenerator {
                 for (final typeParam in builders)
                   Parameter(
                     (b) => b
-                      ..name = 'builderFunc${typeParam.name3!.camelCase()}'
+                      ..name = 'builderFunc${typeParam.name!.camelCase()}'
                       ..type = TypeReference(
                         (b) => b
                           ..symbol = 'AggregateBuilderFunc'
-                          ..types.add(refer('\$${typeParam.name3}')),
+                          ..types.add(refer('\$${typeParam.name}')),
                       )
                       ..named = true
                       ..required = true,
@@ -226,9 +222,9 @@ class AggregateGenerator {
               ])
               ..initializers.addAll([
                 for (final typeParam in builders)
-                  refer('_builderFunc${typeParam.name3!.camelCase()}')
+                  refer('_builderFunc${typeParam.name!.camelCase()}')
                       .assign(
-                        refer('builderFunc${typeParam.name3!.camelCase()}'),
+                        refer('builderFunc${typeParam.name!.camelCase()}'),
                       )
                       .code,
               ]),
@@ -238,12 +234,12 @@ class AggregateGenerator {
           for (final typeParam in builders)
             Field(
               (b) => b
-                ..name = '_builderFunc${typeParam.name3!.camelCase()}'
+                ..name = '_builderFunc${typeParam.name!.camelCase()}'
                 ..modifier = FieldModifier.final$
                 ..type = TypeReference(
                   (b) => b
                     ..symbol = 'AggregateBuilderFunc'
-                    ..types.add(refer('\$${typeParam.name3}')),
+                    ..types.add(refer('\$${typeParam.name}')),
                 ),
             ),
         ])
@@ -256,7 +252,7 @@ class AggregateGenerator {
     bool isRoot = false,
   }) {
     if (type is! InterfaceType || !TypeAnalyzer.isCustomClass(type)) {
-      if (!TypeChecker.fromRuntime(num).isAssignableFromType(type)) {
+      if (!TypeChecker.typeNamed(num).isAssignableFromType(type)) {
         return TypeReference((b) => b..symbol = 'Never');
       }
       return TypeReference(
@@ -266,15 +262,15 @@ class AggregateGenerator {
       );
     }
     final map = Map.fromIterables(
-      type.element3.typeParameters2,
+      type.element.typeParameters,
       type.typeArguments,
     );
-    final builders = computeNeededBuilders(type: type.element3.thisType);
+    final builders = computeNeededBuilders(type: type.element.thisType);
     return TypeReference(
       (b) => b
         ..symbol = isRoot
-            ? '${type.element3.name3}AggregateBuilderRoot'
-            : '${type.element3.name3}AggregateFieldSelector'
+            ? '${type.element.name}AggregateBuilderRoot'
+            : '${type.element.name}AggregateFieldSelector'
         ..types.addAll(
           map.entries.expand(
             (t) => [
@@ -290,17 +286,17 @@ class AggregateGenerator {
     required InterfaceType type,
   }) {
     final map = Map.fromIterables(
-      type.element3.typeParameters2,
+      type.element.typeParameters,
       type.typeArguments,
     );
-    final builders = computeNeededBuilders(type: type.element3.thisType);
+    final builders = computeNeededBuilders(type: type.element.thisType);
 
     return Map.fromEntries(
       map.entries
           .where((entry) => builders.contains(entry.key))
           .map(
             (entry) => MapEntry(
-              'builderFunc${entry.key.name3!.camelCase()}',
+              'builderFunc${entry.key.name!.camelCase()}',
               Method(
                 (b) => b
                   ..lambda = true
@@ -336,7 +332,7 @@ class AggregateGenerator {
     bool isRoot = false,
   }) {
     if (!isUserType(type) &&
-        !TypeChecker.fromRuntime(num).isAssignableFromType(type)) {
+        !TypeChecker.typeNamed(num).isAssignableFromType(type)) {
       return refer(
         'throw UnsupportedError',
       ).call([literalString('Unsupported type for aggregation')]);

--- a/packages/firestore_odm_builder/lib/src/generators/converter_generator.dart
+++ b/packages/firestore_odm_builder/lib/src/generators/converter_generator.dart
@@ -35,7 +35,7 @@ class ConverterGenerator {
     var allInt = true;
 
     for (final c in constants) {
-      final ann = TypeChecker.fromRuntime(JsonValue).firstAnnotationOfExact(c);
+      final ann = TypeChecker.typeNamed(JsonValue).firstAnnotationOfExact(c);
       dynamic raw;
       if (ann != null) {
         final reader = ConstantReader(ann);
@@ -65,7 +65,7 @@ class ConverterGenerator {
         allInt = false;
       }
 
-      final keyEnum = refer('${type.element3.name3}.${c.name}');
+      final keyEnum = refer('${type.element.name}.${c.name}');
       entriesTo.add(MapEntry(keyEnum, jsonLit));
       entriesFrom.add(MapEntry(jsonLit, keyEnum));
     }
@@ -125,7 +125,7 @@ class ConverterGenerator {
       return value.asA(getJsonType(type: type));
     }
 
-    if (TypeChecker.fromRuntime(DateTime).isAssignableFromType(type)) {
+    if (TypeChecker.typeNamed(DateTime).isAssignableFromType(type)) {
       return _handleNullalbe(
         type,
         value,
@@ -133,7 +133,7 @@ class ConverterGenerator {
       );
     }
 
-    if (TypeChecker.fromRuntime(Duration).isAssignableFromType(type)) {
+    if (TypeChecker.typeNamed(Duration).isAssignableFromType(type)) {
       return _handleNullalbe(
         type,
         value,
@@ -141,7 +141,7 @@ class ConverterGenerator {
       );
     }
 
-    if (TypeChecker.fromRuntime(List).isAssignableFromType(type)) {
+    if (TypeChecker.typeNamed(List).isAssignableFromType(type)) {
       return _handleNullalbe(
         type,
         value,
@@ -155,7 +155,7 @@ class ConverterGenerator {
       );
     }
 
-    if (TypeChecker.fromRuntime(Map).isAssignableFromType(type)) {
+    if (TypeChecker.typeNamed(Map).isAssignableFromType(type)) {
       return _handleNullalbe(
         type,
         value,
@@ -176,7 +176,7 @@ class ConverterGenerator {
     if (type is InterfaceType) {
       final expectedType = getJsonType(type: type);
 
-      final toJson = type.lookUpMethod3('toJson', type.element3.library2);
+      final toJson = type.lookUpMethod('toJson', type.element.library);
       if (toJson != null) {
         final args = [
           for (final type in type.typeArguments)
@@ -196,15 +196,15 @@ class ConverterGenerator {
 
       return TypeReference(
         (b) => b
-          ..symbol = '\$${type.element3.name3}ToJson'.lowerFirst()
+          ..symbol = '\$${type.element.name}ToJson'.lowerFirst()
           ..types.addAll(type.typeArguments.map((t) => t.reference)),
       ).call([
         value,
-        for (final typeParam in type.element3.typeParameters2)
+        for (final typeParam in type.element.typeParameters)
           typeConverters[typeParam] ??
               getToJsonEnsured(
                 type:
-                    type.typeArguments[type.element3.typeParameters2.indexOf(
+                    type.typeArguments[type.element.typeParameters.indexOf(
                       typeParam,
                     )],
                 typeConverters: typeConverters,
@@ -249,7 +249,7 @@ class ConverterGenerator {
       return value.asA(type.reference);
     }
 
-    if (TypeChecker.fromRuntime(DateTime).isAssignableFromType(type)) {
+    if (TypeChecker.typeNamed(DateTime).isAssignableFromType(type)) {
       return _handleNullalbe(
         type,
         value,
@@ -259,7 +259,7 @@ class ConverterGenerator {
       );
     }
 
-    if (TypeChecker.fromRuntime(Duration).isAssignableFromType(type)) {
+    if (TypeChecker.typeNamed(Duration).isAssignableFromType(type)) {
       return _handleNullalbe(
         type,
         value,
@@ -269,7 +269,7 @@ class ConverterGenerator {
       );
     }
 
-    if (TypeChecker.fromRuntime(List).isAssignableFromType(type)) {
+    if (TypeChecker.typeNamed(List).isAssignableFromType(type)) {
       return _handleNullalbe(
         type,
         value,
@@ -283,7 +283,7 @@ class ConverterGenerator {
       );
     }
 
-    if (TypeChecker.fromRuntime(Map).isAssignableFromType(type)) {
+    if (TypeChecker.typeNamed(Map).isAssignableFromType(type)) {
       return _handleNullalbe(
         type,
         value,
@@ -305,10 +305,7 @@ class ConverterGenerator {
 
     if (type is InterfaceType) {
       final expectedType = type.reference;
-      final fromJson = type.lookUpConstructor2(
-        'fromJson',
-        type.element3.library2,
-      );
+      final fromJson = type.lookUpConstructor('fromJson', type.element.library);
       if (fromJson != null) {
         final args = [
           for (final type in type.typeArguments)
@@ -338,17 +335,17 @@ class ConverterGenerator {
 
       return TypeReference(
         (b) => b
-          ..symbol = '\$${type.element3.name3}FromJson'.lowerFirst()
+          ..symbol = '\$${type.element.name}FromJson'.lowerFirst()
           ..types.addAll(type.typeArguments.map((t) => t.reference)),
       ).call([
         value.asA(
           TypeReferences.mapOf(TypeReferences.string, TypeReferences.dynamic),
         ),
-        for (final typeParam in type.element3.typeParameters2)
+        for (final typeParam in type.element.typeParameters)
           typeConverters[typeParam] ??
               getFromJsonEnsured(
                 type:
-                    type.typeArguments[type.element3.typeParameters2.indexOf(
+                    type.typeArguments[type.element.typeParameters.indexOf(
                       typeParam,
                     )],
                 typeConverters: typeConverters,
@@ -399,9 +396,9 @@ class ConverterGenerator {
     final fields = getFields(type);
     return Method(
       (b) => b
-        ..name = '\$${type.element3.name3}ToJson'.lowerFirst()
-        ..docs.addAll(['/// Converts ${type.name} to JSON map'])
-        ..types.addAll(type.element3.typeParameters2.map((t) => t.reference))
+        ..name = '\$${type.element.name}ToJson'.lowerFirst()
+        ..docs.addAll(['/// Converts ${type.element.name} to JSON map'])
+        ..types.addAll(type.element.typeParameters.map((t) => t.reference))
         ..returns = TypeReferences.mapOf(
           TypeReferences.string,
           TypeReferences.dynamic,
@@ -412,10 +409,10 @@ class ConverterGenerator {
               ..name = 'data'
               ..type = type.reference,
           ),
-          for (final typeParam in type.element3.typeParameters2)
+          for (final typeParam in type.element.typeParameters)
             Parameter(
               (b) => b
-                ..name = '${typeParam.name3}ToJson'.lowerFirst()
+                ..name = '${typeParam.name}ToJson'.lowerFirst()
                 ..type = FunctionType(
                   (b) => b
                     ..returnType = refer('dynamic')
@@ -432,8 +429,7 @@ class ConverterGenerator {
               typeConverters: {
                 for (final (i, typeParam) in type.typeArguments.indexed)
                   typeParam: refer(
-                    '${type.element3.typeParameters2[i].name3}ToJson'
-                        .lowerFirst(),
+                    '${type.element.typeParameters[i].name}ToJson'.lowerFirst(),
                   ),
               },
             ).code,
@@ -445,9 +441,9 @@ class ConverterGenerator {
     final fields = getFields(type);
     return Method(
       (b) => b
-        ..name = '\$${type.element3.name3}FromJson'.lowerFirst()
-        ..docs.addAll(['/// Converts JSON map to ${type.name}'])
-        ..types.addAll(type.element3.typeParameters2.map((t) => t.reference))
+        ..name = '\$${type.element.name}FromJson'.lowerFirst()
+        ..docs.addAll(['/// Converts JSON map to ${type.element.name}'])
+        ..types.addAll(type.element.typeParameters.map((t) => t.reference))
         ..returns = type.reference
         ..requiredParameters.addAll([
           Parameter(
@@ -458,10 +454,10 @@ class ConverterGenerator {
                 TypeReferences.dynamic,
               ),
           ),
-          for (final typeParam in type.element3.typeParameters2)
+          for (final typeParam in type.element.typeParameters)
             Parameter(
               (b) => b
-                ..name = '${typeParam.name3}FromJson'.lowerFirst()
+                ..name = '${typeParam.name}FromJson'.lowerFirst()
                 ..type = FunctionType(
                   (b) => b
                     ..returnType = typeParam.reference
@@ -479,7 +475,7 @@ class ConverterGenerator {
                   typeConverters: {
                     for (final (i, typeParam) in type.typeArguments.indexed)
                       typeParam: refer(
-                        '${type.element3.typeParameters2[i].name3}FromJson'
+                        '${type.element.typeParameters[i].name}FromJson'
                             .lowerFirst(),
                       ),
                   },
@@ -494,13 +490,13 @@ class ConverterGenerator {
     final specs = <Spec>[];
 
     // Generate toJson method
-    if (type.lookUpMethod3('toJson', type.element3.library2) == null) {
+    if (type.lookUpMethod('toJson', type.element.library) == null) {
       final toJsonMethod = generateToJsonMethod(type: type);
       specs.add(toJsonMethod);
     }
 
     // Generate fromJson method
-    if (type.lookUpConstructor2('fromJson', type.element3.library2) == null) {
+    if (type.lookUpConstructor('fromJson', type.element.library) == null) {
       final fromJsonMethod = generateFromJsonMethod(type: type);
       specs.add(fromJsonMethod);
     }

--- a/packages/firestore_odm_builder/lib/src/generators/filter_generator.dart
+++ b/packages/firestore_odm_builder/lib/src/generators/filter_generator.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:firestore_odm_builder/src/generators/converter_generator.dart';
@@ -52,13 +52,13 @@ class FilterGenerator {
       (b) => b
         ..name = '${className}FilterBuilder'
         ..types.addAll(
-          type.element3.typeParameters2.expand(
+          type.element.typeParameters.expand(
             (t) => [
               t.reference,
               if (builders.contains(t))
                 TypeReference(
                   (b) => b
-                    ..symbol = '\$${t.name3}'
+                    ..symbol = '\$${t.name}'
                     ..bound = refer('FilterBuilderNode'),
                 ),
             ],
@@ -74,11 +74,11 @@ class FilterGenerator {
                 for (final typeParam in builders)
                   Parameter(
                     (b) => b
-                      ..name = 'builderFunc${typeParam.name3!.camelCase()}'
+                      ..name = 'builderFunc${typeParam.name!.camelCase()}'
                       ..type = TypeReference(
                         (b) => b
                           ..symbol = 'FilterBuilderFunc'
-                          ..types.add(refer('\$${typeParam.name3}')),
+                          ..types.add(refer('\$${typeParam.name}')),
                       )
                       ..named = true
                       ..required = true,
@@ -92,9 +92,9 @@ class FilterGenerator {
               ])
               ..initializers.addAll([
                 for (final typeParam in builders)
-                  refer('_builderFunc${typeParam.name3!.camelCase()}')
+                  refer('_builderFunc${typeParam.name!.camelCase()}')
                       .assign(
-                        refer('builderFunc${typeParam.name3!.camelCase()}'),
+                        refer('builderFunc${typeParam.name!.camelCase()}'),
                       )
                       .code,
               ]),
@@ -104,12 +104,12 @@ class FilterGenerator {
           for (final typeParam in builders)
             Field(
               (b) => b
-                ..name = '_builderFunc${typeParam.name3!.camelCase()}'
+                ..name = '_builderFunc${typeParam.name!.camelCase()}'
                 ..modifier = FieldModifier.final$
                 ..type = TypeReference(
                   (b) => b
                     ..symbol = 'FilterBuilderFunc'
-                    ..types.add(refer('\$${typeParam.name3}')),
+                    ..types.add(refer('\$${typeParam.name}')),
                 ),
             ),
         ])
@@ -118,20 +118,20 @@ class FilterGenerator {
   }
 
   static Class generateRootFilterSelectorClass(InterfaceType type) {
-    final className = type.element3.name3;
-    final builders = computeNeededBuilders(type: type.element3.thisType);
+    final className = type.element.name;
+    final builders = computeNeededBuilders(type: type.element.thisType);
     // Create extension
     return Class(
       (b) => b
         ..name = '${className}FilterBuilderRoot'
         ..types.addAll(
-          type.element3.typeParameters2.expand(
+          type.element.typeParameters.expand(
             (t) => [
               t.reference,
               if (builders.contains(t))
                 TypeReference(
                   (b) => b
-                    ..symbol = '\$${t.name3}'
+                    ..symbol = '\$${t.name}'
                     ..bound = refer('FilterBuilderNode'),
                 ),
             ],
@@ -141,11 +141,11 @@ class FilterGenerator {
           (b) => b
             ..symbol = '${className}FilterBuilder'
             ..types.addAll(
-              type.element3.typeParameters2.expand(
+              type.element.typeParameters.expand(
                 (t) => [
                   t.reference,
                   if (builders.contains(t))
-                    TypeReference((b) => b..symbol = '\$${t.name3}'),
+                    TypeReference((b) => b..symbol = '\$${t.name}'),
                 ],
               ),
             ),
@@ -158,11 +158,11 @@ class FilterGenerator {
               ..docs.add('/// Creates a root filter selector for `$className`')
               ..optionalParameters.addAll([
                 for (final typeParam in computeNeededBuilders(
-                  type: type.element3.thisType,
+                  type: type.element.thisType,
                 ))
                   Parameter(
                     (b) => b
-                      ..name = 'builderFunc${typeParam.name3!.camelCase()}'
+                      ..name = 'builderFunc${typeParam.name!.camelCase()}'
                       ..toSuper = true
                       ..named = true
                       ..required = true,
@@ -173,12 +173,12 @@ class FilterGenerator {
     );
   }
 
-  static Set<TypeParameterElement2> computeNeededBuilders({
+  static Set<TypeParameterElement> computeNeededBuilders({
     required InterfaceType type,
   }) {
     final map = Map.fromIterables(
       type.typeArguments,
-      type.element3.typeParameters2,
+      type.element.typeParameters,
     );
     final fields = getFields(type);
     final fieldTypes = fields.values.map((field) => field.type).toSet();
@@ -216,8 +216,8 @@ class FilterGenerator {
   }) {
     if (type is TypeParameterType) {
       return TypeDefinition(
-        type: TypeReference((b) => b..symbol = '\$${type.element3.name3}'),
-        instance: refer('_builderFunc${type.element3.name3!.camelCase()}'),
+        type: TypeReference((b) => b..symbol = '\$${type.element.name}'),
+        instance: refer('_builderFunc${type.element.name!.camelCase()}'),
         // namedArguments: {
         //   'toJson': ConverterGenerator.getToJsonEnsured(
         //     type: field.type,
@@ -252,16 +252,16 @@ class FilterGenerator {
     if (jsonType.symbol == 'Map') {
       if (type is InterfaceType && TypeAnalyzer.isCustomClass(type)) {
         final map = Map.fromIterables(
-          type.element3.typeParameters2,
+          type.element.typeParameters,
           type.typeArguments,
         );
-        final builders = computeNeededBuilders(type: type.element3.thisType);
+        final builders = computeNeededBuilders(type: type.element.thisType);
         return TypeDefinition(
           type: TypeReference(
             (b) => b
               ..symbol = isRoot
-                  ? '${type.element3.name3}FilterBuilderRoot'
-                  : '${type.element3.name3}FilterBuilder'
+                  ? '${type.element.name}FilterBuilderRoot'
+                  : '${type.element.name}FilterBuilder'
               ..types.addAll(
                 map.entries.expand(
                   (t) => [
@@ -350,7 +350,7 @@ class FilterGenerator {
   static TypeReference getRootFilterBuilderType(InterfaceType type) {
     return TypeReference(
       (b) => b
-        ..symbol = type.element.name + 'FilterBuilderRoot'
+        ..symbol = type.element.name! + 'FilterBuilderRoot'
         ..types.addAll(type.typeArguments.map((t) => t.reference)),
     );
   }
@@ -359,17 +359,17 @@ class FilterGenerator {
     required InterfaceType type,
   }) {
     final map = Map.fromIterables(
-      type.element3.typeParameters2,
+      type.element.typeParameters,
       type.typeArguments,
     );
-    final builders = computeNeededBuilders(type: type.element3.thisType);
+    final builders = computeNeededBuilders(type: type.element.thisType);
 
     return Map.fromEntries(
       map.entries
           .where((entry) => builders.contains(entry.key))
           .map(
             (entry) => MapEntry(
-              'builderFunc${entry.key.name3!.camelCase()}',
+              'builderFunc${entry.key.name!.camelCase()}',
               Method(
                 (b) => b
                   ..lambda = true

--- a/packages/firestore_odm_builder/lib/src/generators/order_by_generator.dart
+++ b/packages/firestore_odm_builder/lib/src/generators/order_by_generator.dart
@@ -1,5 +1,4 @@
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart' hide FunctionType;
 import 'package:code_builder/code_builder.dart';
 import 'package:firestore_odm_builder/src/utils/reference_utils.dart';
@@ -21,11 +20,9 @@ class OrderByGenerator {
     };
     if (field.type is TypeParameterType) {
       return TypeDefinition(
-        type: TypeReference(
-          (b) => b..symbol = '\$${field.type.element3!.name3}',
-        ),
+        type: TypeReference((b) => b..symbol = '\$${field.type.element!.name}'),
         instance: refer(
-          '_orderByBuilderFunc${field.type.element3!.name3!.camelCase()}',
+          '_orderByBuilderFunc${field.type.element!.name!.camelCase()}',
         ),
         namedArguments: args,
       );
@@ -36,7 +33,7 @@ class OrderByGenerator {
       return TypeDefinition(
         type: TypeReference(
           (b) => b
-            ..symbol = '${field.type.element3!.name3}OrderByBuilder'
+            ..symbol = '${field.type.element!.name}OrderByBuilder'
             ..types.addAll(field.type.typeArguments.map((e) => e.reference)),
         ),
         namedArguments: args,
@@ -91,18 +88,18 @@ class OrderByGenerator {
     );
   }
 
-  static Map<TypeParameterElement2, InterfaceType> matchedBuilders({
+  static Map<TypeParameterElement, InterfaceType> matchedBuilders({
     required InterfaceType type,
   }) {
     final builders = computeNeededBuilders(type: type);
     final map = Map.fromIterables(
-      type.element3.typeParameters2,
+      type.element.typeParameters,
       type.typeArguments,
     );
     return Map.fromEntries(
       map.entries
           .where((entry) => builders.contains(entry.key))
-          .whereType<MapEntry<TypeParameterElement2, InterfaceType>>(),
+          .whereType<MapEntry<TypeParameterElement, InterfaceType>>(),
     );
   }
 
@@ -110,17 +107,17 @@ class OrderByGenerator {
     required InterfaceType type,
   }) {
     final map = Map.fromIterables(
-      type.element3.typeParameters2,
+      type.element.typeParameters,
       type.typeArguments,
     );
-    final builders = computeNeededBuilders(type: type.element3.thisType);
+    final builders = computeNeededBuilders(type: type.element.thisType);
 
     return Map.fromEntries(
       map.entries
           .where((entry) => builders.contains(entry.key))
           .map(
             (entry) => MapEntry(
-              'orderByBuilderFunc${entry.key.name3!.camelCase()}',
+              'orderByBuilderFunc${entry.key.name!.camelCase()}',
               Method(
                 (b) => b
                   ..lambda = true
@@ -149,12 +146,12 @@ class OrderByGenerator {
     );
   }
 
-  static Set<TypeParameterElement2> computeNeededBuilders({
+  static Set<TypeParameterElement> computeNeededBuilders({
     required InterfaceType type,
   }) {
     final map = Map.fromIterables(
       type.typeArguments,
-      type.element3.typeParameters2,
+      type.element.typeParameters,
     );
     final fields = getFields(type);
     final fieldTypes = fields.values.map((field) => field.type).toSet();
@@ -176,13 +173,13 @@ class OrderByGenerator {
       (b) => b
         ..name = '${className}OrderByBuilder'
         ..types.addAll(
-          type.element3.typeParameters2.expand(
+          type.element.typeParameters.expand(
             (t) => [
               t.reference,
               if (builders.contains(t))
                 TypeReference(
                   (b) => b
-                    ..symbol = '\$${t.name3}'
+                    ..symbol = '\$${t.name}'
                     ..bound = refer('OrderByFieldNode'),
                 ),
             ],
@@ -206,11 +203,11 @@ class OrderByGenerator {
                   Parameter(
                     (b) => b
                       ..name =
-                          'orderByBuilderFunc${typeParam.name3!.camelCase()}'
+                          'orderByBuilderFunc${typeParam.name!.camelCase()}'
                       ..type = TypeReference(
                         (b) => b
                           ..symbol = 'OrderByBuilderFunc'
-                          ..types.add(refer('\$${typeParam.name3}')),
+                          ..types.add(refer('\$${typeParam.name}')),
                       )
                       ..named = true
                       ..required = true,
@@ -224,10 +221,10 @@ class OrderByGenerator {
               ])
               ..initializers.addAll([
                 for (final typeParam in builders)
-                  refer('_orderByBuilderFunc${typeParam.name3!.camelCase()}')
+                  refer('_orderByBuilderFunc${typeParam.name!.camelCase()}')
                       .assign(
                         refer(
-                          'orderByBuilderFunc${typeParam.name3!.camelCase()}',
+                          'orderByBuilderFunc${typeParam.name!.camelCase()}',
                         ),
                       )
                       .code,
@@ -238,12 +235,12 @@ class OrderByGenerator {
           for (final typeParam in builders)
             Field(
               (b) => b
-                ..name = '_orderByBuilderFunc${typeParam.name3!.camelCase()}'
+                ..name = '_orderByBuilderFunc${typeParam.name!.camelCase()}'
                 ..modifier = FieldModifier.final$
                 ..type = TypeReference(
                   (b) => b
                     ..symbol = 'OrderByBuilderFunc'
-                    ..types.add(refer('\$${typeParam.name3}')),
+                    ..types.add(refer('\$${typeParam.name}')),
                 ),
             ),
           ...methods,
@@ -269,13 +266,13 @@ class OrderByGenerator {
       );
     }
     final map = Map.fromIterables(
-      type.element3.typeParameters2,
+      type.element.typeParameters,
       type.typeArguments,
     );
-    final builders = computeNeededBuilders(type: type.element3.thisType);
+    final builders = computeNeededBuilders(type: type.element.thisType);
     return TypeReference(
       (b) => b
-        ..symbol = '${type.element3.name3}OrderByBuilder'
+        ..symbol = '${type.element.name}OrderByBuilder'
         ..types.addAll(
           map.entries.expand(
             (t) => [

--- a/packages/firestore_odm_builder/lib/src/generators/schema_generator.dart
+++ b/packages/firestore_odm_builder/lib/src/generators/schema_generator.dart
@@ -78,11 +78,12 @@ class SchemaGenerator {
   /// Extract the assigned value from a variable element (e.g., "_$TestSchema" from "final testSchema = _$TestSchema;")
   static String _extractAssignedValue(TopLevelVariableElement variableElement) {
     try {
-      // Try to get the source location and extract the assigned value
-      final source = variableElement.source;
-      if (source != null) {
+      // Try to get the source location and extract the assigned value.
+      // analyzer's new element model exposes source via the library fragment.
+      final source = variableElement.library.firstFragment.source;
+      final name = variableElement.name;
+      if (name != null) {
         final contents = source.contents.data;
-        final name = variableElement.name;
 
         // Find the variable declaration line
         final lines = contents.split('\n');
@@ -111,7 +112,7 @@ class SchemaGenerator {
     }
 
     // Fallback: generate from variable name following the convention
-    return '_\$${variableElement.name.upperFirst()}';
+    return '_\$${variableElement.name!.upperFirst()}';
   }
 
   /// Generate document class name from collection path
@@ -204,7 +205,7 @@ class SchemaGenerator {
         );
       }
     }
-    const odmTypeChecker = TypeChecker.fromRuntime(FirestoreOdm);
+    const odmTypeChecker = TypeChecker.typeNamed(FirestoreOdm);
     final missingAnnotations = collections
         .expand((c) => scan(c.modelType))
         .where(isUserType)
@@ -230,7 +231,7 @@ class SchemaGenerator {
     specs.addAll(generateCollectionIdentifiers(collections));
 
     // Use variable name for clean class name (e.g., "schema" -> "Schema", "helloSchema" -> "HelloSchema")
-    final variableName = variableElement.name;
+    final variableName = variableElement.name!;
     final schemaClassName = variableName.upperFirst();
 
     // Extract the assigned value (e.g., "_$TestSchema") for the const name

--- a/packages/firestore_odm_builder/lib/src/generators/update_generator.dart
+++ b/packages/firestore_odm_builder/lib/src/generators/update_generator.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart' hide FunctionType;
 import 'package:code_builder/code_builder.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
@@ -54,10 +54,10 @@ class UpdateGenerator {
         : isTypeParameter
         ? Updater(
             type: TypeReference(
-              (b) => b..symbol = '\$${field.type.element3!.name3}',
+              (b) => b..symbol = '\$${field.type.element!.name}',
             ),
             initializerRef: refer(
-              '_builderFunc${field.type.element3!.name3!.camelCase()}',
+              '_builderFunc${field.type.element!.name!.camelCase()}',
             ),
             arguments: {
               'field': refer(
@@ -110,7 +110,7 @@ class UpdateGenerator {
               ).property('append').call([literalString(jsonFieldName)]),
             },
           )
-        : TypeChecker.fromRuntime(IMap).isAssignableFromType(fieldType)
+        : TypeChecker.typeNamed(IMap).isAssignableFromType(fieldType)
         ? Updater(
             type: TypeReference(
               (b) => b
@@ -140,7 +140,7 @@ class UpdateGenerator {
               ),
             },
           )
-        : TypeChecker.fromRuntime(Map).isAssignableFromType(fieldType)
+        : TypeChecker.typeNamed(Map).isAssignableFromType(fieldType)
         ? Updater(
             type: TypeReference(
               (b) => b
@@ -241,12 +241,12 @@ class UpdateGenerator {
     );
   }
 
-  static Set<TypeParameterElement2> computeNeededBuilders({
+  static Set<TypeParameterElement> computeNeededBuilders({
     required InterfaceType type,
   }) {
     final map = Map.fromIterables(
       type.typeArguments,
-      type.element3.typeParameters2,
+      type.element.typeParameters,
     );
     final fields = getFields(type);
     final fieldTypes = fields.values.map((field) => field.type).toSet();
@@ -262,12 +262,12 @@ class UpdateGenerator {
     }
   }
 
-  static Set<TypeParameterElement2> computeNeededToJsons({
+  static Set<TypeParameterElement> computeNeededToJsons({
     required InterfaceType type,
   }) {
     final map = Map.fromIterables(
       type.typeArguments,
-      type.element3.typeParameters2,
+      type.element.typeParameters,
     );
     final fields = getFields(type);
     final fieldTypes = fields.values
@@ -286,8 +286,8 @@ class UpdateGenerator {
     final toJsons = computeNeededToJsons(type: type);
     return Class(
       (b) => b
-        ..docs.add('/// Patch builder for `${type.name}` model')
-        ..name = '${type.name}PatchBuilder'
+        ..docs.add('/// Patch builder for `${type.element.name}` model')
+        ..name = '${type.element.name}PatchBuilder'
         ..types.add(
           TypeReference(
             (b) => b
@@ -296,13 +296,13 @@ class UpdateGenerator {
           ),
         )
         ..types.addAll(
-          type.element3.typeParameters2.expand(
+          type.element.typeParameters.expand(
             (t) => [
               t.reference,
               if (builders.contains(t))
                 TypeReference(
                   (b) => b
-                    ..symbol = '\$${t.name3}'
+                    ..symbol = '\$${t.name}'
                     ..bound = TypeReference(
                       (b) => b
                         ..symbol = 'PatchBuilder'
@@ -326,18 +326,20 @@ class UpdateGenerator {
         ..constructors.add(
           Constructor(
             (b) => b
-              ..docs.add('/// Creates a patch builder for `${type.name}`')
+              ..docs.add(
+                '/// Creates a patch builder for `${type.element.name}`',
+              )
               ..optionalParameters.addAll([
                 for (final typeParam in builders)
                   Parameter(
                     (b) => b
-                      ..name = 'builderFunc${typeParam.name3!.camelCase()}'
+                      ..name = 'builderFunc${typeParam.name!.camelCase()}'
                       ..type = TypeReference(
                         (b) => b
                           ..symbol = 'PatchBuilderFunc'
                           ..types.addAll([
-                            refer('${typeParam.name3}'),
-                            refer('\$${typeParam.name3}'),
+                            refer('${typeParam.name}'),
+                            refer('\$${typeParam.name}'),
                           ]),
                       )
                       ..named = true
@@ -346,7 +348,7 @@ class UpdateGenerator {
                 for (final typeParam in toJsons)
                   Parameter(
                     (b) => b
-                      ..name = 'toJson${typeParam.name3}'
+                      ..name = 'toJson${typeParam.name}'
                       ..type = FunctionType(
                         (b) => b
                           ..returnType = refer('dynamic')
@@ -371,15 +373,15 @@ class UpdateGenerator {
               ])
               ..initializers.addAll([
                 for (final typeParam in builders)
-                  refer('_builderFunc${typeParam.name3!.camelCase()}')
+                  refer('_builderFunc${typeParam.name!.camelCase()}')
                       .assign(
-                        refer('builderFunc${typeParam.name3!.camelCase()}'),
+                        refer('builderFunc${typeParam.name!.camelCase()}'),
                       )
                       .code,
                 for (final typeParam in toJsons)
                   refer(
-                    '_toJson${typeParam.name3}',
-                  ).assign(refer('toJson${typeParam.name3}')).code,
+                    '_toJson${typeParam.name}',
+                  ).assign(refer('toJson${typeParam.name}')).code,
               ]),
           ),
         )
@@ -387,7 +389,7 @@ class UpdateGenerator {
           for (final typeParam in toJsons)
             Field(
               (b) => b
-                ..name = '_toJson${typeParam.name3}'
+                ..name = '_toJson${typeParam.name}'
                 ..modifier = FieldModifier.final$
                 ..type = FunctionType(
                   (b) => b
@@ -398,14 +400,14 @@ class UpdateGenerator {
           for (final typeParam in builders)
             Field(
               (b) => b
-                ..name = '_builderFunc${typeParam.name3!.camelCase()}'
+                ..name = '_builderFunc${typeParam.name!.camelCase()}'
                 ..modifier = FieldModifier.final$
                 ..type = TypeReference(
                   (b) => b
                     ..symbol = 'PatchBuilderFunc'
                     ..types.addAll([
-                      refer('${typeParam.name3}'),
-                      refer('\$${typeParam.name3}'),
+                      refer('${typeParam.name}'),
+                      refer('\$${typeParam.name}'),
                     ]),
                 ),
             ),
@@ -415,7 +417,7 @@ class UpdateGenerator {
               typeConverters: {
                 for (var (i, typeParam) in type.typeArguments.indexed)
                   typeParam: refer(
-                    '_toJson${type.element3.typeParameters2[i].name3}',
+                    '_toJson${type.element.typeParameters[i].name}',
                   ),
               },
             ),
@@ -434,7 +436,7 @@ class UpdateGenerator {
 
   static TypeReference getBuilderType({required DartType type}) {
     if (type is! InterfaceType || !TypeAnalyzer.isCustomClass(type)) {
-      if (!TypeChecker.fromRuntime(num).isAssignableFromType(type)) {
+      if (!TypeChecker.typeNamed(num).isAssignableFromType(type)) {
         return TypeReference((b) => b..symbol = 'Never');
       }
       return TypeReference(
@@ -445,13 +447,13 @@ class UpdateGenerator {
       );
     }
     final map = Map.fromIterables(
-      type.element3.typeParameters2,
+      type.element.typeParameters,
       type.typeArguments,
     );
-    final builders = computeNeededBuilders(type: type.element3.thisType);
+    final builders = computeNeededBuilders(type: type.element.thisType);
     return TypeReference(
       (b) => b
-        ..symbol = '${type.element3.name3}PatchBuilder'
+        ..symbol = '${type.element.name}PatchBuilder'
         ..types.add(type.reference)
         ..types.addAll(
           map.entries.expand(
@@ -469,15 +471,15 @@ class UpdateGenerator {
     Map<DartType, Expression> typeConverters = const {},
   }) {
     final map = Map.fromIterables(
-      type.element3.typeParameters2,
+      type.element.typeParameters,
       type.typeArguments,
     );
-    final builders = computeNeededBuilders(type: type.element3.thisType);
-    final toJsons = computeNeededToJsons(type: type.element3.thisType);
+    final builders = computeNeededBuilders(type: type.element.thisType);
+    final toJsons = computeNeededToJsons(type: type.element.thisType);
 
     return {
       for (final typeParam in builders)
-        'builderFunc${typeParam.name3!.camelCase()}': Method(
+        'builderFunc${typeParam.name!.camelCase()}': Method(
           (b) => b
             ..lambda = true
             ..optionalParameters.addAll([
@@ -496,7 +498,7 @@ class UpdateGenerator {
         ).closure,
 
       for (final typeParam in toJsons)
-        'toJson${typeParam.name3}': ConverterGenerator.getToJsonEnsured(
+        'toJson${typeParam.name}': ConverterGenerator.getToJsonEnsured(
           type: map[typeParam]!,
           typeConverters: typeConverters,
         ),
@@ -509,7 +511,7 @@ class UpdateGenerator {
     Map<DartType, Expression> typeConverters = const {},
   }) {
     if (!isUserType(type) &&
-        !TypeChecker.fromRuntime(num).isAssignableFromType(type)) {
+        !TypeChecker.typeNamed(num).isAssignableFromType(type)) {
       return refer(
         'throw UnsupportedError',
       ).call([literalString('Unsupported type for aggregation')]);

--- a/packages/firestore_odm_builder/lib/src/schema_generator.dart
+++ b/packages/firestore_odm_builder/lib/src/schema_generator.dart
@@ -45,7 +45,7 @@ class SchemaGenerator2 extends GeneratorForAnnotation<Schema> {
   ) {
     final collections = <SchemaCollectionInfo>[];
 
-    for (final annotation in element.metadata) {
+    for (final annotation in element.metadata.annotations) {
       final annotationValue = annotation.computeConstantValue();
       if (annotationValue?.type?.element?.name == 'Collection') {
         // Extract path from @Collection("path")
@@ -71,7 +71,7 @@ class SchemaGenerator2 extends GeneratorForAnnotation<Schema> {
               modelTypeName: modelTypeName,
               path: path,
               isSubcollection: isSubcollection,
-              schemaTypeName: element.name.upperFirst(),
+              schemaTypeName: element.name!.upperFirst(),
               modelType: modelType, // Store the actual DartType
             ),
           );

--- a/packages/firestore_odm_builder/lib/src/utils/model_analyzer.dart
+++ b/packages/firestore_odm_builder/lib/src/utils/model_analyzer.dart
@@ -49,11 +49,11 @@ class FieldInfo {
 /// - Enums (serialized via name or @JsonValue)
 bool isHandledType(DartType type) {
   return isPrimitive(type) ||
-      TypeChecker.fromRuntime(Iterable).isAssignableFromType(type) ||
-      TypeChecker.fromRuntime(Map).isAssignableFromType(type) ||
-      TypeChecker.fromRuntime(IMap).isAssignableFromType(type) ||
-      TypeChecker.fromRuntime(DateTime).isExactlyType(type) ||
-      TypeChecker.fromRuntime(Duration).isExactlyType(type) ||
+      TypeChecker.typeNamed(Iterable).isAssignableFromType(type) ||
+      TypeChecker.typeNamed(Map).isAssignableFromType(type) ||
+      TypeChecker.typeNamed(IMap).isAssignableFromType(type) ||
+      TypeChecker.typeNamed(DateTime).isExactlyType(type) ||
+      TypeChecker.typeNamed(Duration).isExactlyType(type) ||
       (type is InterfaceType && type.element is EnumElement);
 }
 
@@ -74,7 +74,7 @@ bool isPrimitive(DartType type) {
       type.isDartCoreDouble ||
       type.isDartCoreString ||
       type.isDartCoreNull ||
-      type.name == 'dynamic';
+      type is DynamicType;
 }
 
 Map<String, FieldInfo> getFields(InterfaceType type) {
@@ -90,20 +90,20 @@ Map<String, FieldInfo> getFields(InterfaceType type) {
   final fields = Map<String, FieldInfo>();
 
   // Simplified field analysis
-  for (final parameter in constructor.parameters) {
+  for (final parameter in constructor.formalParameters) {
     if (parameter.isStatic) continue;
 
-    var jsonName = parameter.name;
+    final paramName = parameter.name!;
+    var jsonName = paramName;
     // check JsonKey annotation for custom names
-    if (parameter.metadata.isNotEmpty) {
-      final jsonKey = TypeChecker.fromRuntime(
+    if (parameter.metadata.annotations.isNotEmpty) {
+      final jsonKey = TypeChecker.typeNamed(
         JsonKey,
       ).firstAnnotationOfExact(parameter);
       if (jsonKey != null) {
         final reader = ConstantReader(jsonKey);
 
-        jsonName =
-            reader.read('name').literalValue as String? ?? parameter.name;
+        jsonName = reader.read('name').literalValue as String? ?? paramName;
 
         final includeFromJson =
             reader.read('includeFromJson').literalValue as bool? ?? true;
@@ -115,13 +115,13 @@ Map<String, FieldInfo> getFields(InterfaceType type) {
       }
     }
     final customConverter =
-        TypeChecker.fromRuntime(
+        TypeChecker.typeNamed(
               JsonConverter,
             ).annotationsOf(parameter).firstOrNull?.type
             as InterfaceType?;
 
-    fields[parameter.name] = FieldInfo(
-      parameterName: parameter.name,
+    fields[paramName] = FieldInfo(
+      parameterName: paramName,
       jsonName: jsonName,
       type: parameter.type,
       element: parameter,
@@ -129,7 +129,7 @@ Map<String, FieldInfo> getFields(InterfaceType type) {
           ? CustomConverter(
               type: customConverter,
               jsonType: customConverter
-                  .lookUpMethod3('toJson', customConverter.element3.library2)!
+                  .lookUpMethod('toJson', customConverter.element.library)!
                   .returnType,
             )
           : null,
@@ -143,8 +143,9 @@ Map<String, FieldInfo> getFields(InterfaceType type) {
 }
 
 ConstructorElement? getDefaultConstructor(InterfaceType type) {
+  // analyzer's new element model names the unnamed constructor 'new' (not '').
   final constructor = type.constructors
-      .where((c) => c.name.isEmpty)
+      .where((c) => c.name == 'new' || (c.name ?? '').isEmpty)
       .firstOrNull;
 
   return constructor;
@@ -155,28 +156,28 @@ String getDocumentIdFieldName(InterfaceType type) {
 
   if (constructor == null) {
     throw ArgumentError(
-      'No default constructor found in ${type.getDisplayString(withNullability: false)}',
+      'No default constructor found in ${type.getDisplayString()}',
     );
   }
 
-  final params = constructor.parameters.where(
-    (p) => TypeChecker.fromRuntime(DocumentIdField).hasAnnotationOf(p),
+  final params = constructor.formalParameters.where(
+    (p) => TypeChecker.typeNamed(DocumentIdField).hasAnnotationOf(p),
   );
 
   if (params.length > 1) {
     throw ArgumentError(
-      'Multiple document ID fields found in ${type.getDisplayString(withNullability: false)}',
+      'Multiple document ID fields found in ${type.getDisplayString()}',
     );
   }
 
   final documentIdParam = params.length == 1
       ? params.single
-      : constructor.parameters.where((p) => p.name == 'id').firstOrNull;
+      : constructor.formalParameters.where((p) => p.name == 'id').firstOrNull;
 
   // Check type
   if (documentIdParam != null && !documentIdParam.type.isDartCoreString) {
     throw ArgumentError(
-      'Document ID field must be a String in ${type.getDisplayString(withNullability: false)}',
+      'Document ID field must be a String in ${type.getDisplayString()}',
     );
   }
 
@@ -197,7 +198,7 @@ TypeReference getJsonType({required DartType type}) {
     var allInt = true;
 
     for (final c in constants) {
-      final ann = TypeChecker.fromRuntime(JsonValue).firstAnnotationOfExact(c);
+      final ann = TypeChecker.typeNamed(JsonValue).firstAnnotationOfExact(c);
       if (ann == null) {
         // default = name -> String
         continue;
@@ -225,22 +226,22 @@ TypeReference getJsonType({required DartType type}) {
     return base.withNullability(type.isNullable);
   }
 
-  if (TypeChecker.fromRuntime(DateTime).isAssignableFromType(type)) {
+  if (TypeChecker.typeNamed(DateTime).isAssignableFromType(type)) {
     return TypeReferences.string.withNullability(type.isNullable);
   }
 
-  if (TypeChecker.fromRuntime(Duration).isAssignableFromType(type)) {
+  if (TypeChecker.typeNamed(Duration).isAssignableFromType(type)) {
     return TypeReferences.int.withNullability(type.isNullable);
   }
 
-  if (TypeChecker.fromRuntime(Iterable).isAssignableFromType(type)) {
+  if (TypeChecker.typeNamed(Iterable).isAssignableFromType(type)) {
     return TypeReferences.listOf(
       getJsonType(type: type.typeArguments.first),
     ).withNullability(type.isNullable);
   }
 
-  if (TypeChecker.fromRuntime(Map).isAssignableFromType(type) ||
-      TypeChecker.fromRuntime(IMap).isAssignableFromType(type)) {
+  if (TypeChecker.typeNamed(Map).isAssignableFromType(type) ||
+      TypeChecker.typeNamed(IMap).isAssignableFromType(type)) {
     return TypeReferences.mapOf(
       TypeReferences.string,
       getJsonType(type: type.typeArguments.last),

--- a/packages/firestore_odm_builder/lib/src/utils/reference_utils.dart
+++ b/packages/firestore_odm_builder/lib/src/utils/reference_utils.dart
@@ -1,21 +1,20 @@
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:code_builder/code_builder.dart';
 
 extension DartTypeExtension on DartType {
   TypeReference get reference {
-    final element = this.element3;
+    final element = this.element;
     if (element == null) {
       throw ArgumentError('DartType must have a valid element');
     }
-    final name = element.name3;
+    final name = element.name;
     if (name == 'dynamic') {
       return TypeReference((b) => b..symbol = 'dynamic');
     }
 
-    final uri = element.library2?.uri.toString();
+    final uri = element.library?.uri.toString();
     final typeArguments = switch (this) {
       InterfaceType type => type.typeArguments.map((t) => t.reference).toList(),
       _ => <TypeReference>[],
@@ -59,6 +58,7 @@ extension DartTypeExtension on DartType {
 
 extension ElementExtension on Element {
   TypeReference get reference {
+    final name = this.name;
     if (name == null) {
       throw ArgumentError('Element must have a valid name');
     }
@@ -66,35 +66,10 @@ extension ElementExtension on Element {
       return TypeReference((b) => b..symbol = 'dynamic');
     }
     final library = this.library;
-    final uri = library?.source.uri.toString();
-    final typeParameters = switch (this) {
-      ClassElement e => e.typeParameters.toList(),
-      TypeAliasElement e => e.typeParameters.toList(),
-      _ => <TypeParameterElement>[],
-    };
-    return TypeReference(
-      (b) => b
-        ..symbol = name
-        ..url = uri
-        ..types.addAll(typeParameters.map((t) => t.reference)),
-    );
-  }
-}
-
-extension Element3Extension on Element2 {
-  TypeReference get reference {
-    final name = this.name3;
-    if (name == null) {
-      throw ArgumentError('Element must have a valid name');
-    }
-    if (name == 'dynamic') {
-      return TypeReference((b) => b..symbol = 'dynamic');
-    }
-    final library = this.library2;
     final uri = library?.uri.toString();
     final typeParameters = switch (this) {
-      TypeParameterizedElement2 e => e.typeParameters2.toList(),
-      _ => <TypeParameterElement2>[],
+      TypeParameterizedElement e => e.typeParameters.toList(),
+      _ => <TypeParameterElement>[],
     };
     return TypeReference(
       (b) => b
@@ -222,7 +197,7 @@ extension ElementIterableX on Iterable<Element> {
   List<TypeReference> get references => map((e) => e.reference).toList();
 }
 
-extension Element2IterableX on Iterable<Element2> {
+extension Element2IterableX on Iterable<Element> {
   List<TypeReference> get references => map((e) => e.reference).toList();
 }
 

--- a/packages/firestore_odm_builder/lib/src/utils/type_analyzer.dart
+++ b/packages/firestore_odm_builder/lib/src/utils/type_analyzer.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
@@ -7,52 +7,51 @@ import 'package:firestore_odm_annotation/firestore_odm_annotation.dart';
 
 /// Utility class for analyzing Dart types in Firestore ODM generation
 class TypeAnalyzer {
-  static final TypeChecker documentIdChecker = TypeChecker.fromRuntime(
+  static final TypeChecker documentIdChecker = TypeChecker.typeNamed(
     DocumentIdField,
   );
 
   // TypeCheckers for robust primitive type checking
-  static const TypeChecker _stringChecker = TypeChecker.fromRuntime(String);
-  static const TypeChecker _intChecker = TypeChecker.fromRuntime(int);
-  static const TypeChecker _doubleChecker = TypeChecker.fromRuntime(double);
-  static const TypeChecker _boolChecker = TypeChecker.fromRuntime(bool);
-  static const TypeChecker _numChecker = TypeChecker.fromRuntime(num);
-  static const TypeChecker _dateTimeChecker = TypeChecker.fromRuntime(DateTime);
-  static const TypeChecker _durationChecker = TypeChecker.fromRuntime(Duration);
+  static const TypeChecker _stringChecker = TypeChecker.typeNamed(String);
+  static const TypeChecker _intChecker = TypeChecker.typeNamed(int);
+  static const TypeChecker _doubleChecker = TypeChecker.typeNamed(double);
+  static const TypeChecker _boolChecker = TypeChecker.typeNamed(bool);
+  static const TypeChecker _numChecker = TypeChecker.typeNamed(num);
+  static const TypeChecker _dateTimeChecker = TypeChecker.typeNamed(DateTime);
+  static const TypeChecker _durationChecker = TypeChecker.typeNamed(Duration);
 
   // TypeCheckers for collection types - use Iterable to support any iterable
-  static const TypeChecker _iterableChecker = TypeChecker.fromRuntime(Iterable);
-  static const TypeChecker _listChecker = TypeChecker.fromRuntime(List);
-  static const TypeChecker _mapChecker = TypeChecker.fromRuntime(Map);
+  static const TypeChecker _iterableChecker = TypeChecker.typeNamed(Iterable);
+  static const TypeChecker _listChecker = TypeChecker.typeNamed(List);
+  static const TypeChecker _mapChecker = TypeChecker.typeNamed(Map);
 
-  static const TypeChecker _immutableCollectionChecker =
-      TypeChecker.fromRuntime(ImmutableCollection);
-  static const TypeChecker _immutableMapChecker = TypeChecker.fromRuntime(IMap);
-  static const TypeChecker _immutableListChecker = TypeChecker.fromRuntime(
-    IList,
+  static const TypeChecker _immutableCollectionChecker = TypeChecker.typeNamed(
+    ImmutableCollection,
   );
-  static const TypeChecker _immutableSetChecker = TypeChecker.fromRuntime(ISet);
+  static const TypeChecker _immutableMapChecker = TypeChecker.typeNamed(IMap);
+  static const TypeChecker _immutableListChecker = TypeChecker.typeNamed(IList);
+  static const TypeChecker _immutableSetChecker = TypeChecker.typeNamed(ISet);
 
   /// Find the document ID field in a constructor
   /// First looks for fields with @DocumentIdField() annotation.
   /// If none found, defaults to a field named 'id' (must be String type).
-  static String? getDocumentIdField(ConstructorElement2 constructor) {
+  static String? getDocumentIdField(ConstructorElement constructor) {
     // First pass: Look for explicit @DocumentIdField() annotation
     for (final param in constructor.formalParameters) {
-      for (final metadata in param.metadata2.annotations) {
+      for (final metadata in param.metadata.annotations) {
         final metadataValue = metadata.computeConstantValue();
         if (metadataValue != null &&
             metadataValue.type != null &&
             documentIdChecker.isExactlyType(metadataValue.type!)) {
-          return param.name3!;
+          return param.name!;
         }
       }
     }
 
     // Second pass: Look for a field named 'id' as default
     for (final param in constructor.formalParameters) {
-      if (param.name3 == 'id' && isStringType(param.type)) {
-        return param.name3!;
+      if (param.name == 'id' && isStringType(param.type)) {
+        return param.name!;
       }
     }
 
@@ -130,7 +129,7 @@ class TypeAnalyzer {
         !_mapChecker.isAssignableFromType(nonNullableType) &&
         // exclude enums from being treated as custom classes
         !(nonNullableType is InterfaceType &&
-            nonNullableType.element3 is EnumElement2) &&
+            nonNullableType.element is EnumElement) &&
         !nonNullableType.isDartCoreType;
   }
 
@@ -213,7 +212,7 @@ class TypeAnalyzer {
   }
 
   static bool isAssignableFromType<T>(DartType type) =>
-      TypeChecker.fromRuntime(T).isAssignableFromType(type);
+      TypeChecker.typeNamed(T).isAssignableFromType(type);
 
   /// Check if a type is numeric (int, double, or num)
   static bool isNumericType(DartType type) =>

--- a/packages/firestore_odm_builder/pubspec.yaml
+++ b/packages/firestore_odm_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firestore_odm_builder
 description: Code generator for Firestore ODM annotations. Generates type-safe Firestore operations from annotated classes.
-version: 4.0.0-dev.3
+version: 4.0.0-dev.4
 homepage: https://github.com/SylphxAI/firestore_odm
 repository: https://github.com/SylphxAI/firestore_odm
 issue_tracker: https://github.com/SylphxAI/firestore_odm/issues
@@ -14,19 +14,22 @@ topics:
   - flutter
 
 environment:
-  sdk: '^3.8.1'
+  sdk: '^3.9.0'
 
 dependencies:
-  build: ^2.4.1
-  source_gen: ^2.0.0
-  analyzer: ^7.4.5
+  build: ^4.0.0
+  source_gen: ^4.2.3
+  # Wide range: the builder code targets the analyzer 8+ "new element model".
+  # Kept open to <14 so downstreams can use current analyzer; consumers that also
+  # use freezed (which currently caps <11) will resolve to analyzer 10.x.
+  analyzer: '>=9.0.0 <14.0.0'
   fast_immutable_collections: ^11.0.4
   json_annotation: ^4.9.0
   firestore_odm_annotation: ^4.0.0-dev.2
-  code_builder: ^4.10.1
+  code_builder: ^4.11.1
 
 dev_dependencies:
-  build_runner: ^2.4.9
+  build_runner: ^2.15.0
   very_good_analysis: ^9.0.0
 
 # Publishing to pub.dev (default when omitted)


### PR DESCRIPTION
Resolves the tech debt tracked in #16: upgrades `firestore_odm_builder` off the deprecated analyzer 7 dual element model so the project builds on **current Flutter stable** and drops the 3.32.8 pin.

## What changed
- **Deps**: `analyzer` `>=9.0.0 <14.0.0` (was `^7.4.5`), `source_gen ^4.2.3`, `build ^4.0.0`, `build_runner ^2.15.0`; **min SDK `^3.9.0`**.
- **Element-model migration**: strip transitional suffixes (`element3`→`element`, `name3`→`name`, `typeParameters2`→`typeParameters`, `library2`→`library`, `lookUpConstructor2`/`lookUpMethod3`→`lookUp*`, `*Element2`→`*Element`); drop deprecated `element2.dart` imports; merge the duplicated `reference` extension.
- **API changes**: `TypeChecker.fromRuntime`→`typeNamed` (removed in source_gen 4); `element.metadata`→`element.metadata.annotations`; element/library `.source`→ library-fragment source / `library.uri`; unnamed constructor name `''`→`'new'`; handle now-nullable `Element.name`.
- **CI**: pin Flutter to current stable **3.44.2** (Dart 3.12.2) in `ci.yml` + `release.yml` (was 3.32.8); bump deliberately rather than floating `channel: stable`.

## Verification (local, Flutter 3.44.2 / Dart 3.12.2)
- `dart analyze` builder: **0 errors** on analyzer 13.3.0 (9 deprecation infos remain — `.name`/`.withNullability`, non-blocking; follow-up).
- `build_runner build` succeeds on analyzer **10.2.0** (resolved alongside freezed 3.2.5, which caps analyzer <11; the builder's wide range lets freezed-free downstreams go higher).
- Full `flutter_example` suite: **503 passed, 9 skipped**.

Ships as `4.0.0-dev.4`. Refs #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)