### PR TITLE
feat!: upgrade to cloud_firestore 6.x (4.0.0-dev.5)

### DIFF
--- a/apps/flutter_example/pubspec.yaml
+++ b/apps/flutter_example/pubspec.yaml
@@ -31,8 +31,8 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.8
-  firebase_core: ^3.6.0
-  cloud_firestore: ^5.4.4
+  firebase_core: ^4.0.0
+  cloud_firestore: ^6.4.0
   freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
   fast_immutable_collections: ^11.0.4
@@ -49,7 +49,7 @@ dev_dependencies:
   build_runner: ^2.4.9
   freezed: ^3.0.6
   json_serializable: ^6.9.5
-  fake_cloud_firestore: ^3.1.0
+  fake_cloud_firestore: ^4.1.0
   test: ^1.25.15
   firestore_odm_builder:
     path: ../../packages/firestore_odm_builder

--- a/melos.yaml
+++ b/melos.yaml
@@ -2,8 +2,11 @@ name: firestore_odm_workspace
 repository: https://github.com/SylphxAI/firestore_odm
 
 packages:
-  - apps/**
-  - packages/**
+  # Direct children only — `**` recurses into apps/flutter_example/build/, where
+  # cloud_firestore 6.6.0's bundled `pipeline_example` package appears twice
+  # (ios + macos SourcePackages) and trips melos' duplicate-name check.
+  - apps/*
+  - packages/*
 
 command:
   version:

--- a/packages/firestore_odm/CHANGELOG.md
+++ b/packages/firestore_odm/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0-dev.5
+
+- **BREAKING**: require `cloud_firestore ^6.4.0` (was `^5.0.0`) and `cloud_firestore_platform_interface ^8.0.0` (was `^6.5.0`). No ODM API changes — the query/CRUD/snapshot surface is unchanged across cloud_firestore 5→6. Apps must upgrade to `cloud_firestore` 6.x and `firebase_core` 4.x (cloud_firestore 6.0 removed the deprecated persistence `Settings` toggles; use `Settings.localCache`).
+
 ## 4.0.0-dev.4
 
 - Bump to match firestore_odm_builder 4.0.0-dev.4 (analyzer 8+ migration). No runtime API changes in this package.

--- a/packages/firestore_odm/pubspec.yaml
+++ b/packages/firestore_odm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firestore_odm
 description: Type-safe Firestore ODM with code generation support. Generate type-safe Firestore operations with annotations.
-version: 4.0.0-dev.4
+version: 4.0.0-dev.5
 homepage: https://github.com/SylphxAI/firestore_odm
 repository: https://github.com/SylphxAI/firestore_odm
 issue_tracker: https://github.com/SylphxAI/firestore_odm/issues
@@ -20,8 +20,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cloud_firestore: ^5.0.0
-  cloud_firestore_platform_interface: ^6.5.0
+  cloud_firestore: ^6.4.0
+  cloud_firestore_platform_interface: ^8.0.0
   meta: ^1.9.1
   firestore_odm_annotation: ^4.0.0-dev.2
 

--- a/packages/firestore_odm_annotation/CHANGELOG.md
+++ b/packages/firestore_odm_annotation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0-dev.5
+
+- Bump version to match other packages.
+
 ## 4.0.0-dev.4
 
 - Bump version to match other packages.

--- a/packages/firestore_odm_annotation/pubspec.yaml
+++ b/packages/firestore_odm_annotation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firestore_odm_annotation
 description: Pure annotations for Firestore ODM code generation. Provides the core annotations used to generate type-safe Firestore ODM code.
-version: 4.0.0-dev.4
+version: 4.0.0-dev.5
 homepage: https://github.com/SylphxAI/firestore_odm
 repository: https://github.com/SylphxAI/firestore_odm
 issue_tracker: https://github.com/SylphxAI/firestore_odm/issues

--- a/packages/firestore_odm_builder/CHANGELOG.md
+++ b/packages/firestore_odm_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0-dev.5
+
+- Bump to match firestore_odm 4.0.0-dev.5 (cloud_firestore 6.x). No builder changes.
+
 ## 4.0.0-dev.4
 
 - Migrate to the analyzer 8+ "new element model": `analyzer` `>=9.0.0 <14.0.0` (was `^7.4.5`), `source_gen` `^4.2.3`, `build` `^4.0.0`. Replaces removed/renamed APIs (`element3`→`element`, `name3`→`name`, `typeParameters2`→`typeParameters`, `lookUpConstructor2`/`lookUpMethod3`→`lookUp*`, `TypeChecker.fromRuntime`→`typeNamed`, `metadata`→`metadata.annotations`, unnamed constructor name `''`→`'new'`).

--- a/packages/firestore_odm_builder/pubspec.yaml
+++ b/packages/firestore_odm_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firestore_odm_builder
 description: Code generator for Firestore ODM annotations. Generates type-safe Firestore operations from annotated classes.
-version: 4.0.0-dev.4
+version: 4.0.0-dev.5
 homepage: https://github.com/SylphxAI/firestore_odm
 repository: https://github.com/SylphxAI/firestore_odm
 issue_tracker: https://github.com/SylphxAI/firestore_odm/issues


### PR DESCRIPTION
**BREAKING**: requires `cloud_firestore ^6.4.0` (was `^5.0.0`). Apps must upgrade `cloud_firestore` to 6.x and `firebase_core` to 4.x.

The ODM's public query/CRUD/snapshot surface is **unchanged** across cloud_firestore 5→6 — no `firestore_odm` API changes, no generated-code changes. The only 6.0 Dart-level break is the removal of deprecated persistence `Settings` toggles (use `Settings.localCache`), which the ODM doesn't wrap.

## Changes
- `firestore_odm`: `cloud_firestore ^6.4.0`, `cloud_firestore_platform_interface ^8.0.0`.
- example: `cloud_firestore ^6.4.0`, `firebase_core ^4.0.0`, `fake_cloud_firestore ^4.1.0` (supports cloud_firestore 6).
- Version → `4.0.0-dev.5`.

## Verification (Flutter 3.44.2)
- `melos bootstrap` + `melos run analyze`: clean.
- `build_runner` regenerates; **full flutter_example suite green (503 passed)** on cloud_firestore 6 + fake_cloud_firestore 4.

Unblocks Firestore Pipelines (#6, needs cloud_firestore >= 6.3.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)