### PR TITLE
feat: experimental Firestore Pipelines support (4.0.0-dev.6)

### DIFF
--- a/apps/flutter_example/test/pipeline_experimental_test.dart
+++ b/apps/flutter_example/test/pipeline_experimental_test.dart
@@ -1,0 +1,53 @@
+/// Experimental coverage for the type-safe Firestore Pipeline wrapper
+/// (`collection.pipeline()` → [TypedPipeline]).
+///
+/// Pipelines are an Enterprise-edition feature and are NOT supported by
+/// `fake_cloud_firestore` or the emulator, so end-to-end `execute()` cannot be
+/// exercised here — that requires a real Enterprise database. These tests only
+/// assert the **type-safe builder API compiles and chains**, and document the
+/// execute() limitation.
+library;
+
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firestore_odm/firestore_odm.dart';
+import 'package:flutter_example/models/user.dart';
+import 'package:flutter_example/test_schema.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late FakeFirebaseFirestore firestore;
+  late FirestoreODM<TestSchema> db;
+
+  setUp(() {
+    firestore = FakeFirebaseFirestore();
+    db = FirestoreODM(testSchema, firestore: firestore);
+  });
+
+  group('Experimental: pipeline() typed builder', () {
+    test('exposes a type-safe, chainable pipeline() (compile-time)', () {
+      // The verification here is at COMPILE time: this closure only type-checks
+      // if the collection exposes `pipeline()` returning a `TypedPipeline<User>`
+      // whose `where`/`sort`/`limit` stages chain and preserve the `User`
+      // element type. It is deliberately never invoked — fake_cloud_firestore
+      // has no pipeline engine (see the next test).
+      Future<List<User>> Function() query = () => db.users
+          .pipeline()
+          .where(Field('age').greaterThanOrEqualValue(18))
+          .sort(Field('age').descending())
+          .limit(20)
+          .execute();
+
+      expect(query, isA<Future<List<User>> Function()>());
+    });
+
+    test(
+      'pipeline() is unsupported by fake_cloud_firestore (Enterprise-only)',
+      () {
+        // Documents the runtime constraint: Pipelines require a real Firestore
+        // Enterprise database; the fake (and the emulator) do not implement them.
+        // This is why pipeline execution cannot be covered by this suite.
+        expect(() => db.users.pipeline(), throwsA(anything));
+      },
+    );
+  });
+}

--- a/docs/adr/0001-firestore-pipelines.md
+++ b/docs/adr/0001-firestore-pipelines.md
@@ -1,0 +1,91 @@
+# ADR 0001 — Firestore Pipelines support
+
+- **Status:** Accepted (minimal slice shipped; full design pending)
+- **Issue:** [#6](https://github.com/SylphxAI/firestore_odm/issues/6)
+- **Depends on:** cloud_firestore ≥ 6.3.0 (shipped in 4.0.0-dev.5)
+
+## Context
+
+Firestore **Pipelines** are a server-side query API (GA 2026-04, Firestore
+**Enterprise edition**) that runs documents through chained **stages**
+(`collection → where → sort → limit → offset → aggregate → select → addFields →
+distinct → unnest → union → findNearest → search → …`). They add JOINs,
+aggregation filtering, array unnesting, vector and full-text search, etc., far
+beyond the classic query engine.
+
+`cloud_firestore` exposes them as:
+
+```dart
+firestore.pipeline()              // -> PipelineSource
+  .collection('users')            // -> Pipeline
+  .where(Field('age').greaterThanValue(18))
+  .sort(Field('age').descending())
+  .limit(10)
+  .execute();                     // -> Future<PipelineSnapshot> { result: List<PipelineResult> }
+```
+
+### Hard constraints (shape the design)
+
+1. **Enterprise edition only.** Running a pipeline against a Standard database
+   is a server error.
+2. **One-shot.** `execute()` only — no realtime listeners, no offline cache.
+3. **Not testable in our suite.** `fake_cloud_firestore` and the emulator do
+   **not** implement `pipeline()` (it throws). End-to-end behaviour can only be
+   validated against a real Enterprise database. Our 503-test suite is
+   fake-based, so pipeline *execution* is uncoverable in CI.
+4. **Result rows are not documents.** A `PipelineResult` is a map (`data()`)
+   plus an optional `document` ref — `select`/`aggregate` rows may have no
+   document at all.
+
+## Decision
+
+Expose pipelines as a **separate, opt-in, execute-only surface** distinct from
+the reactive `.get()/.stream()` query API — never wired into streaming or cache.
+
+### Minimal slice (shipped in this PR)
+
+A runtime wrapper, `TypedPipeline<T>`, reached via `collection.pipeline()`:
+
+- Stages: `where(BooleanExpression)`, `sort(Ordering...)`, `limit(int)`.
+- `execute()` → maps each `PipelineResult.data()` through the model's `fromJson`,
+  injecting the row's document id into the model's document-id field when present.
+- Expression building uses cloud_firestore's `Field('path')` API, re-exported
+  from `firestore_odm` for convenience.
+- Marked **experimental** in docs; covered by a compile-time type-safety test
+  and a test asserting the fake throws (documenting the Enterprise requirement).
+
+This is intentionally string-path (`Field('age')`) rather than fully
+ODM-type-safe — see below.
+
+### Maximal design (follow-up)
+
+1. **Generated per-model field selectors.** Reuse the existing field analysis
+   (the same source that powers filter/orderBy builders) to generate a typed
+   selector so callers write `($) => $.age.gte(18)` / `($) => $.age.descending()`
+   instead of `Field('age')...`. The selector emits the native
+   `BooleanExpression`/`Ordering`. This is the bulk of the work: a new generator
+   producing a `UserPipelineSelector` per model whose leaves know their field
+   paths and types.
+2. **Full stage coverage:** `offset`, `aggregate` (Count/Sum/Average/Min/Max…),
+   `select`/`addFields`/`removeFields`, `distinct`, `unnest`, `union`,
+   `findNearest` (vector), `search` (full-text). Aggregate/select rows return a
+   projected shape, not `T`; model these as `TypedPipeline<T>.aggregate(...)
+   → Future<List<Map>>` or generated projection types.
+3. **Edition guard / docs:** surface a clear error/oc when run against a
+   Standard database, and document the Enterprise + index requirements.
+
+### Testing strategy
+
+- **CI (fake):** compile-time type-safety of the builder + assert `pipeline()`
+  is unsupported by the fake. (Done.)
+- **Enterprise e2e:** a separate, opt-in integration lane against a real
+  Enterprise database, gated so it never runs in the fake suite. Required before
+  pipelines are promoted out of "experimental".
+
+## Consequences
+
+- Users on Standard edition are unaffected (the classic API is unchanged).
+- The feature ships **experimental** until validated on Enterprise.
+- cloud_firestore is now 6.x (4.0.0-dev.5), so the dependency is in place.
+- Promoting pipelines to stable is **blocked on an Enterprise test environment**,
+  not on code — tracked in #6.

--- a/packages/firestore_odm/CHANGELOG.md
+++ b/packages/firestore_odm/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0-dev.6
+
+- **EXPERIMENTAL**: add `collection.pipeline()` → `TypedPipeline<T>`, a type-safe wrapper over Firestore Pipelines (`where`/`sort`/`limit`/`execute`, results mapped back to the model). Pipelines are **Enterprise edition only**, one-shot (no realtime/offline), and unsupported by the emulator / `fake_cloud_firestore` — so execution is not covered by the test suite and needs a real Enterprise database. Re-exports `Field`/`Expression`/`Ordering` for building expressions. Design: `docs/adr/0001-firestore-pipelines.md` (#6).
+
 ## 4.0.0-dev.5
 
 - **BREAKING**: require `cloud_firestore ^6.4.0` (was `^5.0.0`) and `cloud_firestore_platform_interface ^8.0.0` (was `^6.5.0`). No ODM API changes — the query/CRUD/snapshot surface is unchanged across cloud_firestore 5→6. Apps must upgrade to `cloud_firestore` 6.x and `firebase_core` 4.x (cloud_firestore 6.0 removed the deprecated persistence `Settings` toggles; use `Settings.localCache`).

--- a/packages/firestore_odm/lib/firestore_odm.dart
+++ b/packages/firestore_odm/lib/firestore_odm.dart
@@ -11,6 +11,7 @@ export 'src/filter_builder.dart';
 export 'src/model_converter.dart';
 export 'src/schema.dart';
 export 'src/query.dart';
+export 'src/pipeline.dart';
 export 'src/transaction.dart';
 export 'src/batch.dart';
 export 'src/aggregate.dart';

--- a/packages/firestore_odm/lib/src/firestore_collection.dart
+++ b/packages/firestore_odm/lib/src/firestore_collection.dart
@@ -110,6 +110,27 @@ class FirestoreCollection<
   Stream<List<T>> get stream =>
       QueryHandler.stream(query, _fromJson, documentIdField);
 
+  /// **Experimental** — start a Firestore Pipeline over this collection, with
+  /// result rows mapped back to `T`.
+  ///
+  /// Pipelines are a Firestore **Enterprise edition** feature: one-shot
+  /// `execute()` only (no realtime/offline), and unsupported by the emulator or
+  /// `fake_cloud_firestore`. See [TypedPipeline].
+  ///
+  /// ```dart
+  /// final adults = await db.users
+  ///     .pipeline()
+  ///     .where(Field('age').greaterThanOrEqualValue(18))
+  ///     .sort(Field('age').descending())
+  ///     .limit(20)
+  ///     .execute();
+  /// ```
+  TypedPipeline<T> pipeline() => TypedPipeline(
+    query.firestore.pipeline().collection(query.path),
+    _fromJson,
+    documentIdField,
+  );
+
   @override
   OrderedQuery<S, T, O, P, F, OB, AB> orderBy<O extends Record>(
     O Function(OB selector) orderByFunc,

--- a/packages/firestore_odm/lib/src/pipeline.dart
+++ b/packages/firestore_odm/lib/src/pipeline.dart
@@ -1,0 +1,85 @@
+import 'package:cloud_firestore/cloud_firestore.dart' as firestore;
+
+// Re-export the pipeline expression/stage building blocks so callers can write
+// `Field('age').greaterThanValue(18)` / `Field('age').descending()` without
+// importing cloud_firestore directly.
+export 'package:cloud_firestore/cloud_firestore.dart'
+    show
+        Pipeline,
+        PipelineSource,
+        PipelineSnapshot,
+        PipelineResult,
+        Expression,
+        BooleanExpression,
+        Field,
+        Constant,
+        Ordering,
+        ExecuteOptions;
+
+/// **Experimental** — a thin, type-safe wrapper over a Firestore
+/// [firestore.Pipeline] that maps result rows back to the ODM model `T`.
+///
+/// Firestore Pipelines are an **Enterprise edition** feature. They are
+/// **one-shot only** (`execute()`, no realtime listeners or offline cache) and
+/// are **not supported by the emulator or `fake_cloud_firestore`** — so this
+/// surface cannot be exercised by the fake-firestore test suite and must be
+/// validated against a real Enterprise database.
+///
+/// This is the minimal slice (`where` / `sort` / `limit` / `execute`); the full
+/// type-safe, per-model stage/expression builders are designed in
+/// `docs/adr/0001-firestore-pipelines.md` and tracked in
+/// https://github.com/SylphxAI/firestore_odm/issues/6.
+class TypedPipeline<T> {
+  final firestore.Pipeline _pipeline;
+  final T Function(Map<String, dynamic>) _fromJson;
+  final String _documentIdField;
+
+  const TypedPipeline(this._pipeline, this._fromJson, this._documentIdField);
+
+  /// Adds a `where` stage. Build [expression] with `Field('path')` comparisons,
+  /// e.g. `Field('age').greaterThanValue(18)`.
+  TypedPipeline<T> where(firestore.BooleanExpression expression) =>
+      TypedPipeline(_pipeline.where(expression), _fromJson, _documentIdField);
+
+  /// Adds a `sort` stage. Build orderings with `Field('path').ascending()` /
+  /// `.descending()`.
+  TypedPipeline<T> sort(
+    firestore.Ordering order, [
+    firestore.Ordering? order2,
+    firestore.Ordering? order3,
+  ]) {
+    final firestore.Pipeline next;
+    if (order3 != null) {
+      next = _pipeline.sort(order, order2!, order3);
+    } else if (order2 != null) {
+      next = _pipeline.sort(order, order2);
+    } else {
+      next = _pipeline.sort(order);
+    }
+    return TypedPipeline(next, _fromJson, _documentIdField);
+  }
+
+  /// Adds a `limit` stage.
+  TypedPipeline<T> limit(int limit) =>
+      TypedPipeline(_pipeline.limit(limit), _fromJson, _documentIdField);
+
+  /// Executes the pipeline (Enterprise edition; one-shot) and maps each result
+  /// row through the model's `fromJson`.
+  ///
+  /// Pipeline rows are not [firestore.DocumentSnapshot]s, so when a row carries
+  /// a document reference its id is injected into the model's document-id field
+  /// (mirroring the classic read path).
+  Future<List<T>> execute({firestore.ExecuteOptions? options}) async {
+    final snapshot = await _pipeline.execute(options: options);
+    return [for (final row in snapshot.result) _fromJson(_withDocumentId(row))];
+  }
+
+  Map<String, dynamic> _withDocumentId(firestore.PipelineResult row) {
+    final data = Map<String, dynamic>.from(row.data() ?? const {});
+    final id = row.document?.id;
+    if (id != null && !data.containsKey(_documentIdField)) {
+      data[_documentIdField] = id;
+    }
+    return data;
+  }
+}

--- a/packages/firestore_odm/pubspec.yaml
+++ b/packages/firestore_odm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firestore_odm
 description: Type-safe Firestore ODM with code generation support. Generate type-safe Firestore operations with annotations.
-version: 4.0.0-dev.5
+version: 4.0.0-dev.6
 homepage: https://github.com/SylphxAI/firestore_odm
 repository: https://github.com/SylphxAI/firestore_odm
 issue_tracker: https://github.com/SylphxAI/firestore_odm/issues

--- a/packages/firestore_odm_annotation/CHANGELOG.md
+++ b/packages/firestore_odm_annotation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0-dev.6
+
+- Bump version to match other packages.
+
 ## 4.0.0-dev.5
 
 - Bump version to match other packages.

--- a/packages/firestore_odm_annotation/pubspec.yaml
+++ b/packages/firestore_odm_annotation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firestore_odm_annotation
 description: Pure annotations for Firestore ODM code generation. Provides the core annotations used to generate type-safe Firestore ODM code.
-version: 4.0.0-dev.5
+version: 4.0.0-dev.6
 homepage: https://github.com/SylphxAI/firestore_odm
 repository: https://github.com/SylphxAI/firestore_odm
 issue_tracker: https://github.com/SylphxAI/firestore_odm/issues

--- a/packages/firestore_odm_builder/CHANGELOG.md
+++ b/packages/firestore_odm_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0-dev.6
+
+- Bump to match firestore_odm 4.0.0-dev.6 (experimental pipeline API). No builder changes.
+
 ## 4.0.0-dev.5
 
 - Bump to match firestore_odm 4.0.0-dev.5 (cloud_firestore 6.x). No builder changes.

--- a/packages/firestore_odm_builder/pubspec.yaml
+++ b/packages/firestore_odm_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firestore_odm_builder
 description: Code generator for Firestore ODM annotations. Generates type-safe Firestore operations from annotated classes.
-version: 4.0.0-dev.5
+version: 4.0.0-dev.6
 homepage: https://github.com/SylphxAI/firestore_odm
 repository: https://github.com/SylphxAI/firestore_odm
 issue_tracker: https://github.com/SylphxAI/firestore_odm/issues


### PR DESCRIPTION
Adds an **experimental**, type-safe wrapper over Firestore Pipelines — the minimal slice agreed in #6 / ADR 0001.

## API
```dart
final adults = await db.users
    .pipeline()                                       // TypedPipeline<User>
    .where(Field('age').greaterThanOrEqualValue(18))
    .sort(Field('age').descending())
    .limit(20)
    .execute();                                       // Future<List<User>>
```
- `collection.pipeline()` → `TypedPipeline<T>` (runtime wrapper over `cloud_firestore`'s `Pipeline`).
- Stages: `where` / `sort` / `limit`; `execute()` maps each result row through the model `fromJson` (document id injected when present).
- Re-exports `Field` / `Expression` / `Ordering` / `BooleanExpression` for building expressions.

## Important constraints
Pipelines are **Firestore Enterprise edition** only: one-shot `execute()` (no realtime/offline) and **unsupported by `fake_cloud_firestore` / the emulator**. So execution **cannot be covered by the fake-based suite** — verified instead by a compile-time type-safety test and a test asserting the fake rejects `pipeline()`. End-to-end coverage needs a real Enterprise database before this leaves "experimental".

## Design
Full design (per-model typed selectors, all stages, Enterprise e2e lane) in [`docs/adr/0001-firestore-pipelines.md`](docs/adr/0001-firestore-pipelines.md).

## Verification (Flutter 3.44.2)
format:check + analyze clean; **full suite green (505 passed, 9 skipped)**.

Refs #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)