### PR TITLE
chore(release): 4.0.0 stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,9 @@ int age = user.profile.age;  // ✅ Type-safe nested access
 
 Building on 3.0's performance foundation, **4.0 expands type coverage and ergonomics** on top of a fully reworked code generator.
 
-> ℹ️ 4.0 is currently a **pre-release** (`4.0.0-dev`). The current stable line is 3.x.
-
 ### New in 4.0
 - ✅ **Enum support** - `@JsonValue` with both string *and* numeric values, enums in `orderBy()`, and default-value generation
+- 🧪 **Firestore Pipelines** *(experimental)* - `collection.pipeline()` for Enterprise-edition pipeline queries (see the [release notes](https://SylphxAI.github.io/firestore_odm/guide/version-4.0-release-notes.html))
 - ✅ **Automatic nested-class imports** - filter, patch, aggregate, and `orderBy` selectors for nested types need no manual imports
 - ✅ **Stronger nullable handling** - nullable `Map` fields, and nested `fromJson` factories that accept nullable input no longer crash when a field is missing
 - ✅ **Server timestamps on insert** - not only on updates, and honored inside batches

--- a/docs/guide/version-4.0-release-notes.md
+++ b/docs/guide/version-4.0-release-notes.md
@@ -4,10 +4,11 @@ Firestore ODM 4.0 builds on 3.0's performance foundation with a **fully reworked
 code generator**, broader type coverage, and ergonomic wins — while keeping the
 schema, model, query, and update API you already write unchanged.
 
-::: info Pre-release
-4.0 is currently published as a pre-release (`4.0.0-dev`). The current stable
-line is 3.x. There are no intentional breaking changes to the public API;
-4.0 is primarily new capabilities plus a large internal refactor.
+::: warning Breaking: cloud_firestore 6.x
+4.0 requires **`cloud_firestore` 6.x** and **`firebase_core` 4.x** (was
+cloud_firestore 5.x). The ODM's own query/CRUD/update API is unchanged — upgrade
+those two dependencies in your app and re-run the generator. See *Upgrading*
+below.
 :::
 
 ## 🎉 What's New in 4.0
@@ -73,6 +74,27 @@ rebuilt on a unified `FieldPath` model, with a consolidated `TypeDefinition`
 type. This is internal, but it produces cleaner generated code and a more
 consistent foundation for future features.
 
+### 🧪 Firestore Pipelines (experimental)
+
+`collection.pipeline()` returns a type-safe `TypedPipeline<T>` over Firestore's
+new Pipelines API:
+
+```dart
+final adults = await db.users
+    .pipeline()
+    .where(Field('age').greaterThanOrEqualValue(18))
+    .sort(Field('age').descending())
+    .limit(20)
+    .execute(); // -> List<User>
+```
+
+> Pipelines are a **Firestore Enterprise edition** feature: one-shot
+> `execute()` only (no realtime/offline), and **not supported by the emulator or
+> `fake_cloud_firestore`**. This API is **experimental** and must be validated
+> against a real Enterprise database. Design + roadmap:
+> [ADR&nbsp;0001](https://github.com/SylphxAI/firestore_odm/blob/main/docs/adr/0001-firestore-pipelines.md),
+> [#6](https://github.com/SylphxAI/firestore_odm/issues/6).
+
 ## ⚙️ Performance
 
 The performance characteristics established in 3.0 are retained:
@@ -86,22 +108,26 @@ The performance characteristics established in 3.0 are retained:
 
 ## ⬆️ Upgrading from 3.x
 
-The public API is unchanged for typical usage (schema definition, models,
-queries, `patch`/`modify`, transactions, batches). Upgrade by bumping the
-dependency and re-running the generator:
+The ODM's own API is unchanged for typical usage (schema definition, models,
+queries, `patch`/`modify`, transactions, batches). The one required change is
+the **cloud_firestore 6.x / firebase_core 4.x** bump in your app:
 
 ```bash
-dart pub add firestore_odm:^4.0.0-dev
-dart pub add dev:firestore_odm_builder:^4.0.0-dev
+dart pub add firestore_odm:^4.0.0
+dart pub add dev:firestore_odm_builder:^4.0.0
+dart pub add cloud_firestore:^6.4.0
+dart pub add firebase_core:^4.0.0
 dart run build_runner build --delete-conflicting-outputs
 ```
 
-If you depended on internal-only classes (e.g. the removed `BatchField` /
-`BatchConfiguration` helpers, or referenced the internal `Node2` type), prefer
-the public collection/document/patch-builder APIs instead.
+cloud_firestore 6.0 removed the deprecated persistence `Settings` toggles — use
+`Settings.localCache` if you configured those. If you depended on ODM
+internal-only classes (e.g. the removed `BatchField` / `BatchConfiguration`
+helpers, or the internal `Node2` type), prefer the public
+collection/document/patch-builder APIs instead.
 
 ## 🔭 What's next
 
-- [Firestore Pipelines support](https://github.com/SylphxAI/firestore_odm/issues/6)
+- [Firestore Pipelines](https://github.com/SylphxAI/firestore_odm/issues/6): promote out of experimental once validated on Enterprise; add per-model typed selectors and the remaining stages
 - Full map field filtering, ordering, and aggregation
 - Nested map support

--- a/packages/firestore_odm/CHANGELOG.md
+++ b/packages/firestore_odm/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 4.0.0
+
+Stable release of the 4.0 line. Highlights since 3.x:
+
+- **BREAKING**: requires `cloud_firestore ^6.4.0` / `firebase_core ^4.x` (was cloud_firestore 5.x). The ODM query/CRUD/update API is unchanged.
+- Enum support (`@JsonValue` string + numeric, enums in `orderBy`, defaults).
+- Automatic nested-class imports for filter/patch/aggregate/orderBy selectors.
+- Stronger nullable handling, incl. nested `fromJson` factories that accept nullable input (#5).
+- Server timestamps applied on insert (not only update); batch & transaction patch builders.
+- **Experimental**: `collection.pipeline()` for Firestore Pipelines (Enterprise edition only; see ADR-0001 / #6).
+- Reworked code generator; builder now targets the analyzer 8+ element model and current Flutter stable.
+
+See the `4.0.0-dev.*` entries below for the detailed history.
+
 ## 4.0.0-dev.6
 
 - **EXPERIMENTAL**: add `collection.pipeline()` → `TypedPipeline<T>`, a type-safe wrapper over Firestore Pipelines (`where`/`sort`/`limit`/`execute`, results mapped back to the model). Pipelines are **Enterprise edition only**, one-shot (no realtime/offline), and unsupported by the emulator / `fake_cloud_firestore` — so execution is not covered by the test suite and needs a real Enterprise database. Re-exports `Field`/`Expression`/`Ordering` for building expressions. Design: `docs/adr/0001-firestore-pipelines.md` (#6).

--- a/packages/firestore_odm/pubspec.yaml
+++ b/packages/firestore_odm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firestore_odm
 description: Type-safe Firestore ODM with code generation support. Generate type-safe Firestore operations with annotations.
-version: 4.0.0-dev.6
+version: 4.0.0
 homepage: https://github.com/SylphxAI/firestore_odm
 repository: https://github.com/SylphxAI/firestore_odm
 issue_tracker: https://github.com/SylphxAI/firestore_odm/issues
@@ -23,7 +23,7 @@ dependencies:
   cloud_firestore: ^6.4.0
   cloud_firestore_platform_interface: ^8.0.0
   meta: ^1.9.1
-  firestore_odm_annotation: ^4.0.0-dev.2
+  firestore_odm_annotation: ^4.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/firestore_odm_annotation/CHANGELOG.md
+++ b/packages/firestore_odm_annotation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.0
+
+Stable release of the 4.0 line (version kept in lockstep with the other
+packages). See `4.0.0-dev.*` below.
+
 ## 4.0.0-dev.6
 
 - Bump version to match other packages.

--- a/packages/firestore_odm_annotation/pubspec.yaml
+++ b/packages/firestore_odm_annotation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firestore_odm_annotation
 description: Pure annotations for Firestore ODM code generation. Provides the core annotations used to generate type-safe Firestore ODM code.
-version: 4.0.0-dev.6
+version: 4.0.0
 homepage: https://github.com/SylphxAI/firestore_odm
 repository: https://github.com/SylphxAI/firestore_odm
 issue_tracker: https://github.com/SylphxAI/firestore_odm/issues

--- a/packages/firestore_odm_builder/CHANGELOG.md
+++ b/packages/firestore_odm_builder/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.0.0
+
+Stable release of the 4.0 line. Key change since 3.x: migrated to the analyzer
+8+ "new element model" (`analyzer >=9 <14`, source_gen 4, build 4; min Dart
+3.9), enabling builds on current Flutter stable. See `4.0.0-dev.*` below.
+
 ## 4.0.0-dev.6
 
 - Bump to match firestore_odm 4.0.0-dev.6 (experimental pipeline API). No builder changes.

--- a/packages/firestore_odm_builder/pubspec.yaml
+++ b/packages/firestore_odm_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firestore_odm_builder
 description: Code generator for Firestore ODM annotations. Generates type-safe Firestore operations from annotated classes.
-version: 4.0.0-dev.6
+version: 4.0.0
 homepage: https://github.com/SylphxAI/firestore_odm
 repository: https://github.com/SylphxAI/firestore_odm
 issue_tracker: https://github.com/SylphxAI/firestore_odm/issues
@@ -25,7 +25,7 @@ dependencies:
   analyzer: '>=9.0.0 <14.0.0'
   fast_immutable_collections: ^11.0.4
   json_annotation: ^4.9.0
-  firestore_odm_annotation: ^4.0.0-dev.2
+  firestore_odm_annotation: ^4.0.0
   code_builder: ^4.11.1
 
 dev_dependencies:


### PR DESCRIPTION
Promotes the 4.0 line to **stable** (4.0.0-dev.6 → 4.0.0).

No code changes — version bumps + CHANGELOG 4.0.0 entries + docs (README drops the pre-release note and lists Pipelines as experimental; release notes get the cloud_firestore 6.x callout + experimental Pipelines section + ^4.0.0 install).

A (analyzer migration / Flutter unpin) and B (cloud_firestore 6.x) are fully verified; C (Pipelines) ships **experimental** (Enterprise-only, unverifiable in the fake suite — ADR-0001 / #6).

After merge: publish 4.0.0 to pub.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)