### PR TITLE
feat: fully type-safe Firestore Pipelines ($.field selector) — 4.1.0-dev.1

### DIFF
--- a/apps/flutter_example/test/pipeline_experimental_test.dart
+++ b/apps/flutter_example/test/pipeline_experimental_test.dart
@@ -52,7 +52,10 @@ void main() {
           .select(($) => (who: $.name.value, years: $.age.value))
           .execute();
 
-      expect(projected, isA<Future<List<({String who, int years})>> Function()>());
+      expect(
+        projected,
+        isA<Future<List<({String who, int years})>> Function()>(),
+      );
     });
 
     test('aggregate() returns a typed record (compile-time)', () {
@@ -66,12 +69,14 @@ void main() {
       expect(stats, isA<Future<({int count, double avgAge})> Function()>());
     });
 
-    test('pipeline() is unsupported by fake_cloud_firestore (Enterprise-only)',
-        () {
-      // Pipelines require a real Firestore Enterprise database; the fake (and
-      // the emulator) do not implement them. This is why pipeline execution
-      // cannot be covered by this suite.
-      expect(() => db.users.pipeline(), throwsA(anything));
-    });
+    test(
+      'pipeline() is unsupported by fake_cloud_firestore (Enterprise-only)',
+      () {
+        // Pipelines require a real Firestore Enterprise database; the fake (and
+        // the emulator) do not implement them. This is why pipeline execution
+        // cannot be covered by this suite.
+        expect(() => db.users.pipeline(), throwsA(anything));
+      },
+    );
   });
 }

--- a/apps/flutter_example/test/pipeline_experimental_test.dart
+++ b/apps/flutter_example/test/pipeline_experimental_test.dart
@@ -42,6 +42,30 @@ void main() {
       expect(query, isA<Future<List<User>> Function()>());
     });
 
+    test('select() projects into a typed record (compile-time)', () {
+      // Proves `select` returns a `ProjectedPipeline` whose `execute()` yields a
+      // typed record list — projected purely from `$.field`, no strings.
+      Future<List<({String who, int years})>> Function() projected = () => db
+          .users
+          .pipeline()
+          .where(($) => $.age(isGreaterThanOrEqualTo: 18))
+          .select(($) => (who: $.name.value, years: $.age.value))
+          .execute();
+
+      expect(projected, isA<Future<List<({String who, int years})>> Function()>());
+    });
+
+    test('aggregate() returns a typed record (compile-time)', () {
+      // Proves `aggregate` returns a typed record built from `$.field`
+      // aggregates (count-all + per-field average), no strings.
+      Future<({int count, double avgAge})> Function() stats = () => db.users
+          .pipeline()
+          .where(($) => $.age(isGreaterThan: 0))
+          .aggregate(($) => (count: $.count(), avgAge: $.age.average()));
+
+      expect(stats, isA<Future<({int count, double avgAge})> Function()>());
+    });
+
     test('pipeline() is unsupported by fake_cloud_firestore (Enterprise-only)',
         () {
       // Pipelines require a real Firestore Enterprise database; the fake (and

--- a/apps/flutter_example/test/pipeline_experimental_test.dart
+++ b/apps/flutter_example/test/pipeline_experimental_test.dart
@@ -1,11 +1,11 @@
-/// Experimental coverage for the type-safe Firestore Pipeline wrapper
-/// (`collection.pipeline()` → [TypedPipeline]).
+/// Experimental coverage for the **fully type-safe** Firestore Pipeline API
+/// (`collection.pipeline()` → generated `$.field` selector → [TypedPipeline]).
 ///
 /// Pipelines are an Enterprise-edition feature and are NOT supported by
 /// `fake_cloud_firestore` or the emulator, so end-to-end `execute()` cannot be
-/// exercised here — that requires a real Enterprise database. These tests only
-/// assert the **type-safe builder API compiles and chains**, and document the
-/// execute() limitation.
+/// exercised here — that requires a real Enterprise database. These tests assert
+/// the **type-safe `$.field` builder compiles and chains** (no string field
+/// paths), and document the execute() limitation.
 library;
 
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
@@ -23,31 +23,31 @@ void main() {
     db = FirestoreODM(testSchema, firestore: firestore);
   });
 
-  group('Experimental: pipeline() typed builder', () {
-    test('exposes a type-safe, chainable pipeline() (compile-time)', () {
-      // The verification here is at COMPILE time: this closure only type-checks
-      // if the collection exposes `pipeline()` returning a `TypedPipeline<User>`
-      // whose `where`/`sort`/`limit` stages chain and preserve the `User`
-      // element type. It is deliberately never invoked — fake_cloud_firestore
-      // has no pipeline engine (see the next test).
+  group('Experimental: fully-typed pipeline() builder', () {
+    test('builds where/sort/limit from the typed \$.field selector', () {
+      // Compile-time proof: this only type-checks if `pipeline()` returns a
+      // `TypedPipeline<User, UserPipelineSelector>` whose stages take the typed
+      // `$.field` selector (no string `Field('age')`), the comparison value is
+      // typed (`int` for age), nested fields work (`$.profile.followers`), and
+      // the element type stays `User` through the chain. Never invoked —
+      // fake_cloud_firestore has no pipeline engine (next test).
       Future<List<User>> Function() query = () => db.users
           .pipeline()
-          .where(Field('age').greaterThanOrEqualValue(18))
-          .sort(Field('age').descending())
+          .where(($) => $.age(isGreaterThanOrEqualTo: 18))
+          .where(($) => $.profile.followers(isGreaterThan: 100))
+          .sort(($) => $.age.descending(), ($) => $.name.ascending())
           .limit(20)
           .execute();
 
       expect(query, isA<Future<List<User>> Function()>());
     });
 
-    test(
-      'pipeline() is unsupported by fake_cloud_firestore (Enterprise-only)',
-      () {
-        // Documents the runtime constraint: Pipelines require a real Firestore
-        // Enterprise database; the fake (and the emulator) do not implement them.
-        // This is why pipeline execution cannot be covered by this suite.
-        expect(() => db.users.pipeline(), throwsA(anything));
-      },
-    );
+    test('pipeline() is unsupported by fake_cloud_firestore (Enterprise-only)',
+        () {
+      // Pipelines require a real Firestore Enterprise database; the fake (and
+      // the emulator) do not implement them. This is why pipeline execution
+      // cannot be covered by this suite.
+      expect(() => db.users.pipeline(), throwsA(anything));
+    });
   });
 }

--- a/docs/adr/0001-firestore-pipelines.md
+++ b/docs/adr/0001-firestore-pipelines.md
@@ -1,91 +1,126 @@
-# ADR 0001 — Firestore Pipelines support
+# ADR 0001 — Firestore Pipelines support (type-safe)
 
-- **Status:** Accepted (minimal slice shipped; full design pending)
+- **Status:** Accepted — fully type-safe pipeline API implemented
+  (`where`/`sort`/`limit` + `select`/`aggregate`). Compile-time verified;
+  **runtime behaviour pending Enterprise-database validation** (uncoverable by
+  the fake suite).
 - **Issue:** [#6](https://github.com/SylphxAI/firestore_odm/issues/6)
-- **Depends on:** cloud_firestore ≥ 6.3.0 (shipped in 4.0.0-dev.5)
+- **Depends on:** cloud_firestore ≥ 6.3.0 (shipped in 4.0.0)
 
 ## Context
 
-Firestore **Pipelines** are a server-side query API (GA 2026-04, Firestore
-**Enterprise edition**) that runs documents through chained **stages**
-(`collection → where → sort → limit → offset → aggregate → select → addFields →
-distinct → unnest → union → findNearest → search → …`). They add JOINs,
-aggregation filtering, array unnesting, vector and full-text search, etc., far
-beyond the classic query engine.
+Firestore **Pipelines** (GA 2026-04, **Enterprise edition**) run documents
+through chained stages. `cloud_firestore` exposes a string-based,
+`Field('age')`-style API.
 
-`cloud_firestore` exposes them as:
+**Non-negotiable for this project:** firestore_odm exists to eliminate string
+field paths and `Map<String,dynamic>` — everything is type-safe via codegen
+(`$.profile.followers`, typed values, `User` results). A pipeline API built on
+`Field('age')` (as an earlier experimental slice was) **directly contradicts the
+library's reason to exist** and is rejected.
 
-```dart
-firestore.pipeline()              // -> PipelineSource
-  .collection('users')            // -> Pipeline
-  .where(Field('age').greaterThanValue(18))
-  .sort(Field('age').descending())
-  .limit(10)
-  .execute();                     // -> Future<PipelineSnapshot> { result: List<PipelineResult> }
-```
+### Hard constraints
 
-### Hard constraints (shape the design)
-
-1. **Enterprise edition only.** Running a pipeline against a Standard database
-   is a server error.
-2. **One-shot.** `execute()` only — no realtime listeners, no offline cache.
-3. **Not testable in our suite.** `fake_cloud_firestore` and the emulator do
-   **not** implement `pipeline()` (it throws). End-to-end behaviour can only be
-   validated against a real Enterprise database. Our 503-test suite is
-   fake-based, so pipeline *execution* is uncoverable in CI.
-4. **Result rows are not documents.** A `PipelineResult` is a map (`data()`)
-   plus an optional `document` ref — `select`/`aggregate` rows may have no
-   document at all.
+1. **Enterprise edition only**; running on Standard is a server error.
+2. **One-shot** `execute()` — no realtime/offline.
+3. **Not testable in our suite.** `fake_cloud_firestore` and the emulator do not
+   implement `pipeline()` (it throws). Pipeline **execution is uncoverable in
+   CI** — only compile-time type-safety is. Anything beyond that needs a real
+   Enterprise database.
+4. Result rows are maps (`PipelineResult.data()`) + an optional `document` ref.
 
 ## Decision
 
-Expose pipelines as a **separate, opt-in, execute-only surface** distinct from
-the reactive `.get()/.stream()` query API — never wired into streaming or cache.
+A separate, execute-only surface, **fully type-safe via the same `$.field`
+codegen used by `where`/`orderBy`/`aggregate`** — never string paths.
 
-### Minimal slice (shipped in this PR)
+### Implemented (this line)
 
-A runtime wrapper, `TypedPipeline<T>`, reached via `collection.pipeline()`:
+Per non-generic model the builder generates `<Model>PipelineSelector` (leaves =
+`PipelineField<T>` carrying their `FieldPath` + `toJson`; nested objects = nested
+selectors) and a covariant `pipeline()` extension on the model's
+`FirestoreCollection`. Runtime `TypedPipeline<T, S>`:
 
-- Stages: `where(BooleanExpression)`, `sort(Ordering...)`, `limit(int)`.
-- `execute()` → maps each `PipelineResult.data()` through the model's `fromJson`,
-  injecting the row's document id into the model's document-id field when present.
-- Expression building uses cloud_firestore's `Field('path')` API, re-exported
-  from `firestore_odm` for convenience.
-- Marked **experimental** in docs; covered by a compile-time type-safety test
-  and a test asserting the fake throws (documenting the Enterprise requirement).
+```dart
+final adults = await db.users
+    .pipeline()
+    .where(($) => $.age(isGreaterThanOrEqualTo: 18))   // typed value, no strings
+    .where(($) => $.profile.followers(isGreaterThan: 100))
+    .sort(($) => $.age.descending())
+    .limit(20)
+    .execute();                                         // -> List<User>
+```
 
-This is intentionally string-path (`Field('age')`) rather than fully
-ODM-type-safe — see below.
+These **preserve the row type `T`**, so they map straight back through the
+model's `fromJson`. This is the verified foundation (compile-time tests; full
+suite green).
 
-### Maximal design (follow-up)
+### Implemented — shape-changing stages (`select`, `aggregate`)
 
-1. **Generated per-model field selectors.** Reuse the existing field analysis
-   (the same source that powers filter/orderBy builders) to generate a typed
-   selector so callers write `($) => $.age.gte(18)` / `($) => $.age.descending()`
-   instead of `Field('age')...`. The selector emits the native
-   `BooleanExpression`/`Ordering`. This is the bulk of the work: a new generator
-   producing a `UserPipelineSelector` per model whose leaves know their field
-   paths and types.
-2. **Full stage coverage:** `offset`, `aggregate` (Count/Sum/Average/Min/Max…),
-   `select`/`addFields`/`removeFields`, `distinct`, `unnest`, `union`,
-   `findNearest` (vector), `search` (full-text). Aggregate/select rows return a
-   projected shape, not `T`; model these as `TypedPipeline<T>.aggregate(...)
-   → Future<List<Map>>` or generated projection types.
-3. **Edition guard / docs:** surface a clear error/oc when run against a
-   Standard database, and document the Enterprise + index requirements.
+These change the row shape, so the result is **not `T`** — they return **typed
+Dart records** via dual-phase replay, mirroring the existing `aggregate`
+subsystem (`AggregateBuilderContext` vs `AggregateResultContext`):
 
-### Testing strategy
+```dart
+// projection -> List of typed records
+final rows = await db.users.pipeline()
+    .select(($) => (name: $.name.value, years: $.age.value))   // -> List<({String name, int years})>
+    .execute();
 
-- **CI (fake):** compile-time type-safety of the builder + assert `pipeline()`
-  is unsupported by the fake. (Done.)
-- **Enterprise e2e:** a separate, opt-in integration lane against a real
-  Enterprise database, gated so it never runs in the fake suite. Required before
-  pipelines are promoted out of "experimental".
+// aggregation -> a typed record
+final stats = await db.users.pipeline()
+    .where(($) => $.isActive(isEqualTo: true))
+    .aggregate(($) => (count: $.count(), avgAge: $.age.average()));  // -> ({int count, double avgAge})
+```
+
+Mechanism:
+1. The selector becomes context-capable (a factory `S Function(PipelineContext?)`
+   passed to `TypedPipeline`, like the aggregate selector takes a context).
+2. **Capture pass:** run the record-builder with a capture context; leaves record
+   `AliasedExpression`/`AliasedAggregateFunction` under a deterministic alias and
+   return `defaultValue<T>()` dummies; the captured list builds the native
+   `select`/`aggregate` stage.
+3. **Result pass:** for each result row, re-run the same builder with a row
+   context where leaves return `row[alias]` (coerced to the static type); the
+   record literal in the lambda reassembles the typed record.
+
+Implementation notes / known limits (compile-verified; validate on Enterprise):
+- **Aliasing** is deterministic per (field, op) — `sum_age`, `avg_age`,
+  `count_all`, and the field path for projections. Projecting/aggregating the
+  **same field+op twice** would collide; revisit with order-based aliases if a
+  use case needs it.
+- **Numeric coercion**: Firestore returns `num`; values are coerced to the
+  static record-field type (`int`/`double`), mirroring `AggregateResultContext`.
+- **Native API mapping**: `Field.sum()/average()/minimum()/maximum()/count()` →
+  `PipelineAggregateFunction`; count-all via `CountAll`; `Field.alias()` for
+  projections; fanned out to the positional `aggregate()/select()` API (≤8 for
+  now).
+- `select` is currently terminal (`.execute()` → `List<record>`); chaining
+  further stages after a projection is a follow-up.
+
+### Runtime verification gap
+
+`where/sort/limit` are exercised by compile-time tests; `select/aggregate` are
+**compile-time type-checked only** — their replay/aliasing/coercion runtime
+behaviour cannot be exercised by `fake_cloud_firestore` (no pipeline engine) and
+**must be validated against a real Enterprise database** before this leaves
+"experimental".
+
+## Testing strategy
+
+- **CI (fake):** compile-time type-safety of the typed builder + a test asserting
+  the fake rejects `pipeline()`. (Done.)
+- **Enterprise e2e:** an opt-in lane against a real Enterprise database — required
+  before promoting pipelines (and before shipping the shape-changing stages) out
+  of "experimental".
 
 ## Consequences
 
-- Users on Standard edition are unaffected (the classic API is unchanged).
-- The feature ships **experimental** until validated on Enterprise.
-- cloud_firestore is now 6.x (4.0.0-dev.5), so the dependency is in place.
-- Promoting pipelines to stable is **blocked on an Enterprise test environment**,
-  not on code — tracked in #6.
+- Standard-edition users are unaffected; the classic typed API is unchanged.
+- The whole typed surface (`where/sort/limit/select/aggregate`) honours the
+  type-safety promise — no string field paths — and ships experimental.
+- `select`/`aggregate` are implemented (typed records) but compile-verified only;
+  promoting pipelines out of "experimental" is gated on Enterprise validation —
+  tracked in #6.
+- Generic models don't yet get a pipeline surface (the selector + collection
+  type would need the type parameters threaded through) — follow-up.

--- a/docs/guide/version-4.0-release-notes.md
+++ b/docs/guide/version-4.0-release-notes.md
@@ -76,21 +76,34 @@ consistent foundation for future features.
 
 ### 🧪 Firestore Pipelines (experimental)
 
-`collection.pipeline()` returns a type-safe `TypedPipeline<T>` over Firestore's
-new Pipelines API:
+`collection.pipeline()` returns a `TypedPipeline<T>` over Firestore's new
+Pipelines API — built from the **same type-safe `$.field` selector** as the rest
+of the ODM (no string field paths). Row-preserving and shape-changing stages are
+all typed:
 
 ```dart
+// where / sort / limit -> List<User>
 final adults = await db.users
     .pipeline()
-    .where(Field('age').greaterThanOrEqualValue(18))
-    .sort(Field('age').descending())
+    .where(($) => $.age(isGreaterThanOrEqualTo: 18))   // typed value; nested $.profile.x works
+    .sort(($) => $.age.descending())
     .limit(20)
-    .execute(); // -> List<User>
+    .execute();
+
+// select -> typed records
+final rows = await db.users.pipeline()
+    .select(($) => (name: $.name.value, years: $.age.value))
+    .execute(); // -> List<({String name, int years})>
+
+// aggregate -> a typed record
+final stats = await db.users.pipeline()
+    .aggregate(($) => (count: $.count(), avgAge: $.age.average())); // -> ({int count, double avgAge})
 ```
 
 > Pipelines are a **Firestore Enterprise edition** feature: one-shot
 > `execute()` only (no realtime/offline), and **not supported by the emulator or
-> `fake_cloud_firestore`**. This API is **experimental** and must be validated
+> `fake_cloud_firestore`**. This API is **experimental**: it is fully type-checked
+> at compile time, but `select`/`aggregate` runtime behaviour must be validated
 > against a real Enterprise database. Design + roadmap:
 > [ADR&nbsp;0001](https://github.com/SylphxAI/firestore_odm/blob/main/docs/adr/0001-firestore-pipelines.md),
 > [#6](https://github.com/SylphxAI/firestore_odm/issues/6).

--- a/packages/firestore_odm/CHANGELOG.md
+++ b/packages/firestore_odm/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.0-dev.1
+
+- **EXPERIMENTAL**: redesign `collection.pipeline()` to be **fully type-safe via the generated `$.field` selector** — no more string `Field('age')` paths (which contradicted the ODM's purpose). `where`/`sort`/`limit`/`offset` preserve the model type; `select` projects into typed Dart records (`select(($) => (name: $.name.value, years: $.age.value)) → List<({String name, int years})>`); `aggregate` returns a typed record (`aggregate(($) => (count: $.count(), avgAge: $.age.average()))`). Compile-time type-checked; `select`/`aggregate` runtime behaviour still requires an Enterprise database to validate (the fake has no pipeline engine). Generic models don't get a pipeline surface yet. See `docs/adr/0001-firestore-pipelines.md` (#6).
+
 ## 4.0.0
 
 Stable release of the 4.0 line. Highlights since 3.x:

--- a/packages/firestore_odm/lib/src/firestore_collection.dart
+++ b/packages/firestore_odm/lib/src/firestore_collection.dart
@@ -110,26 +110,9 @@ class FirestoreCollection<
   Stream<List<T>> get stream =>
       QueryHandler.stream(query, _fromJson, documentIdField);
 
-  /// **Experimental** — start a Firestore Pipeline over this collection, with
-  /// result rows mapped back to `T`.
-  ///
-  /// Pipelines are a Firestore **Enterprise edition** feature: one-shot
-  /// `execute()` only (no realtime/offline), and unsupported by the emulator or
-  /// `fake_cloud_firestore`. See [TypedPipeline].
-  ///
-  /// ```dart
-  /// final adults = await db.users
-  ///     .pipeline()
-  ///     .where(Field('age').greaterThanOrEqualValue(18))
-  ///     .sort(Field('age').descending())
-  ///     .limit(20)
-  ///     .execute();
-  /// ```
-  TypedPipeline<T> pipeline() => TypedPipeline(
-    query.firestore.pipeline().collection(query.path),
-    _fromJson,
-    documentIdField,
-  );
+  /// The model deserializer for this collection. Exposed so the generated,
+  /// per-model `pipeline()` extension can map pipeline rows back to `T`.
+  T Function(Map<String, dynamic>) get fromJson => _fromJson;
 
   @override
   OrderedQuery<S, T, O, P, F, OB, AB> orderBy<O extends Record>(

--- a/packages/firestore_odm/lib/src/pipeline.dart
+++ b/packages/firestore_odm/lib/src/pipeline.dart
@@ -1,80 +1,154 @@
 import 'package:cloud_firestore/cloud_firestore.dart' as firestore;
 
-// Re-export the pipeline expression/stage building blocks so callers can write
-// `Field('age').greaterThanValue(18)` / `Field('age').descending()` without
-// importing cloud_firestore directly.
+import 'field_selector.dart';
+
+// Re-export only what callers legitimately need at the type level. Note we do
+// NOT re-export `Field` — the whole point is that callers never write string
+// field paths; they use the generated `$.field` selector instead.
 export 'package:cloud_firestore/cloud_firestore.dart'
     show
         Pipeline,
-        PipelineSource,
         PipelineSnapshot,
         PipelineResult,
-        Expression,
         BooleanExpression,
-        Field,
-        Constant,
         Ordering,
         ExecuteOptions;
 
-/// **Experimental** — a thin, type-safe wrapper over a Firestore
-/// [firestore.Pipeline] that maps result rows back to the ODM model `T`.
+/// Base class for generated per-model pipeline selectors (e.g.
+/// `UserPipelineSelector`). Mirrors `FilterBuilderNode` / `OrderByFieldNode`:
+/// each node carries its [FieldPath], and nested objects are nested selectors.
+class PipelineFieldNode extends Node {
+  const PipelineFieldNode({super.field});
+}
+
+/// A type-safe leaf for a scalar field in a pipeline selector.
 ///
-/// Firestore Pipelines are an **Enterprise edition** feature. They are
-/// **one-shot only** (`execute()`, no realtime listeners or offline cache) and
-/// are **not supported by the emulator or `fake_cloud_firestore`** — so this
-/// surface cannot be exercised by the fake-firestore test suite and must be
-/// validated against a real Enterprise database.
+/// It produces native pipeline expressions/orderings/aggregates **from the
+/// field's path** — callers never spell the path as a string. The ergonomics
+/// mirror the classic ODM query API:
 ///
-/// This is the minimal slice (`where` / `sort` / `limit` / `execute`); the full
-/// type-safe, per-model stage/expression builders are designed in
-/// `docs/adr/0001-firestore-pipelines.md` and tracked in
-/// https://github.com/SylphxAI/firestore_odm/issues/6.
-class TypedPipeline<T> {
+/// ```dart
+/// $.age(isGreaterThanOrEqualTo: 18)   // where  -> BooleanExpression
+/// $.age.descending()                  // sort   -> Ordering
+/// $.age.sum().as('total')             // select/aggregate
+/// ```
+class PipelineField<T> extends PipelineFieldNode {
+  const PipelineField({super.field, Object? Function(T)? toJson})
+    : _toJson = toJson;
+
+  /// Converts a typed value to its Firestore JSON form (e.g. enum → its
+  /// `@JsonValue`, DateTime → ISO string), matching how the field is stored.
+  final Object? Function(T)? _toJson;
+
+  /// The underlying native field expression for this leaf's path.
+  firestore.Field get expression => firestore.Field(path.path);
+
+  Object? _json(T value) => _toJson != null ? _toJson(value) : value;
+
+  /// Build a `where` predicate, mirroring the classic filter API. Exactly one
+  /// argument should be supplied.
+  firestore.BooleanExpression call({
+    Object? isEqualTo = _sentinel,
+    Object? isNotEqualTo = _sentinel,
+    Object? isLessThan = _sentinel,
+    Object? isLessThanOrEqualTo = _sentinel,
+    Object? isGreaterThan = _sentinel,
+    Object? isGreaterThanOrEqualTo = _sentinel,
+  }) {
+    if (!identical(isEqualTo, _sentinel)) {
+      return expression.equalValue(_json(isEqualTo as T));
+    }
+    if (!identical(isNotEqualTo, _sentinel)) {
+      return expression.notEqualValue(_json(isNotEqualTo as T));
+    }
+    if (!identical(isLessThan, _sentinel)) {
+      return expression.lessThanValue(_json(isLessThan as T));
+    }
+    if (!identical(isLessThanOrEqualTo, _sentinel)) {
+      return expression.lessThanOrEqualValue(_json(isLessThanOrEqualTo as T));
+    }
+    if (!identical(isGreaterThan, _sentinel)) {
+      return expression.greaterThanValue(_json(isGreaterThan as T));
+    }
+    if (!identical(isGreaterThanOrEqualTo, _sentinel)) {
+      return expression.greaterThanOrEqualValue(
+        _json(isGreaterThanOrEqualTo as T),
+      );
+    }
+    throw ArgumentError('Provide exactly one comparison to a pipeline where()');
+  }
+
+  /// Ascending sort on this field.
+  firestore.Ordering ascending() => expression.ascending();
+
+  /// Descending sort on this field.
+  firestore.Ordering descending() => expression.descending();
+}
+
+const Object _sentinel = Object();
+
+/// A type-safe wrapper over a Firestore [firestore.Pipeline] that keeps the
+/// model element type `T` and exposes the generated selector `S` for building
+/// stages without string field paths.
+///
+/// **Experimental** — Pipelines are a Firestore **Enterprise edition** feature:
+/// one-shot `execute()` (no realtime/offline), and unsupported by the emulator
+/// or `fake_cloud_firestore`. Execution must be validated against a real
+/// Enterprise database; see `docs/adr/0001-firestore-pipelines.md`.
+class TypedPipeline<T, S extends PipelineFieldNode> {
   final firestore.Pipeline _pipeline;
   final T Function(Map<String, dynamic>) _fromJson;
   final String _documentIdField;
+  final S _selector;
 
-  const TypedPipeline(this._pipeline, this._fromJson, this._documentIdField);
+  const TypedPipeline(
+    this._pipeline,
+    this._fromJson,
+    this._documentIdField,
+    this._selector,
+  );
 
-  /// Adds a `where` stage. Build [expression] with `Field('path')` comparisons,
-  /// e.g. `Field('age').greaterThanValue(18)`.
-  TypedPipeline<T> where(firestore.BooleanExpression expression) =>
-      TypedPipeline(_pipeline.where(expression), _fromJson, _documentIdField);
+  TypedPipeline<T, S> _next(firestore.Pipeline p) =>
+      TypedPipeline(p, _fromJson, _documentIdField, _selector);
 
-  /// Adds a `sort` stage. Build orderings with `Field('path').ascending()` /
-  /// `.descending()`.
-  TypedPipeline<T> sort(
-    firestore.Ordering order, [
-    firestore.Ordering? order2,
-    firestore.Ordering? order3,
+  /// `where` stage built from the typed selector, e.g.
+  /// `pipeline.where(($) => $.age(isGreaterThanOrEqualTo: 18))`.
+  TypedPipeline<T, S> where(
+    firestore.BooleanExpression Function(S selector) build,
+  ) => _next(_pipeline.where(build(_selector)));
+
+  /// `sort` stage, e.g. `pipeline.sort(($) => $.age.descending())`. Up to three
+  /// orderings; extend as needed.
+  TypedPipeline<T, S> sort(
+    firestore.Ordering Function(S selector) build, [
+    firestore.Ordering Function(S selector)? build2,
+    firestore.Ordering Function(S selector)? build3,
   ]) {
-    final firestore.Pipeline next;
-    if (order3 != null) {
-      next = _pipeline.sort(order, order2!, order3);
-    } else if (order2 != null) {
-      next = _pipeline.sort(order, order2);
-    } else {
-      next = _pipeline.sort(order);
+    final o1 = build(_selector);
+    if (build3 != null) {
+      return _next(_pipeline.sort(o1, build2!(_selector), build3(_selector)));
     }
-    return TypedPipeline(next, _fromJson, _documentIdField);
+    if (build2 != null) {
+      return _next(_pipeline.sort(o1, build2(_selector)));
+    }
+    return _next(_pipeline.sort(o1));
   }
 
-  /// Adds a `limit` stage.
-  TypedPipeline<T> limit(int limit) =>
-      TypedPipeline(_pipeline.limit(limit), _fromJson, _documentIdField);
+  /// `limit` stage.
+  TypedPipeline<T, S> limit(int limit) => _next(_pipeline.limit(limit));
+
+  /// `offset` stage.
+  TypedPipeline<T, S> offset(int offset) => _next(_pipeline.offset(offset));
 
   /// Executes the pipeline (Enterprise edition; one-shot) and maps each result
-  /// row through the model's `fromJson`.
-  ///
-  /// Pipeline rows are not [firestore.DocumentSnapshot]s, so when a row carries
-  /// a document reference its id is injected into the model's document-id field
-  /// (mirroring the classic read path).
+  /// row through the model's `fromJson`. The document id is injected into the
+  /// model's document-id field when a row carries a document reference.
   Future<List<T>> execute({firestore.ExecuteOptions? options}) async {
     final snapshot = await _pipeline.execute(options: options);
-    return [for (final row in snapshot.result) _fromJson(_withDocumentId(row))];
+    return [for (final row in snapshot.result) _fromJson(_withId(row))];
   }
 
-  Map<String, dynamic> _withDocumentId(firestore.PipelineResult row) {
+  Map<String, dynamic> _withId(firestore.PipelineResult row) {
     final data = Map<String, dynamic>.from(row.data() ?? const {});
     final id = row.document?.id;
     if (id != null && !data.containsKey(_documentIdField)) {

--- a/packages/firestore_odm/lib/src/pipeline.dart
+++ b/packages/firestore_odm/lib/src/pipeline.dart
@@ -29,7 +29,10 @@ export 'package:cloud_firestore/cloud_firestore.dart'
 /// stage. Implementations either capture the native pieces or resolve values
 /// from a result row.
 abstract class PipelineContext {
-  R aggregate<R>(String alias, firestore.PipelineAggregateFunction Function() fn);
+  R aggregate<R>(
+    String alias,
+    firestore.PipelineAggregateFunction Function() fn,
+  );
   R project<R>(String alias, firestore.Field Function() field);
 }
 
@@ -67,8 +70,10 @@ class _RowContext implements PipelineContext {
   }
 
   @override
-  R aggregate<R>(String alias, firestore.PipelineAggregateFunction Function() _) =>
-      _coerce<R>(row[alias]);
+  R aggregate<R>(
+    String alias,
+    firestore.PipelineAggregateFunction Function() _,
+  ) => _coerce<R>(row[alias]);
 
   @override
   R project<R>(String alias, firestore.Field Function() _) =>
@@ -85,8 +90,7 @@ class PipelineFieldNode extends Node {
     : $ctx = context;
 
   /// Count of all rows, for `aggregate(($) => (n: $.count()))`.
-  int count() =>
-      $ctx!.aggregate<int>('count_all', () => firestore.CountAll());
+  int count() => $ctx!.aggregate<int>('count_all', () => firestore.CountAll());
 }
 
 /// A type-safe leaf for a scalar field. Produces native pipeline
@@ -236,7 +240,10 @@ class TypedPipeline<T, S extends PipelineFieldNode> {
     final capture = _CaptureContext();
     build(_selector(capture)); // capture phase
     final p = _applySelect(_pipeline, capture.projections);
-    return ProjectedPipeline<R>._(p, (row) => build(_selector(_RowContext(row))));
+    return ProjectedPipeline<R>._(
+      p,
+      (row) => build(_selector(_RowContext(row))),
+    );
   }
 
   /// Aggregate the (filtered) pipeline into a single typed record, e.g.

--- a/packages/firestore_odm/lib/src/pipeline.dart
+++ b/packages/firestore_odm/lib/src/pipeline.dart
@@ -1,10 +1,11 @@
 import 'package:cloud_firestore/cloud_firestore.dart' as firestore;
 
 import 'field_selector.dart';
+import 'utils.dart' show defaultValue;
 
-// Re-export only what callers legitimately need at the type level. Note we do
-// NOT re-export `Field` — the whole point is that callers never write string
-// field paths; they use the generated `$.field` selector instead.
+// Re-export only the stage/result *types*. Note we do NOT re-export `Field` —
+// the whole point is that callers use the generated `$.field` selector, never
+// string field paths.
 export 'package:cloud_firestore/cloud_firestore.dart'
     show
         Pipeline,
@@ -14,39 +15,103 @@ export 'package:cloud_firestore/cloud_firestore.dart'
         Ordering,
         ExecuteOptions;
 
-/// Base class for generated per-model pipeline selectors (e.g.
-/// `UserPipelineSelector`). Mirrors `FilterBuilderNode` / `OrderByFieldNode`:
-/// each node carries its [FieldPath], and nested objects are nested selectors.
-class PipelineFieldNode extends Node {
-  const PipelineFieldNode({super.field});
+// ---------------------------------------------------------------------------
+// Dual-phase context for shape-changing stages (select / aggregate).
+//
+// Mirrors the classic aggregate subsystem: a *capture* pass records the
+// native expressions (under deterministic aliases) to build the stage, and a
+// *result* pass replays the same record-builder against each result row to
+// reassemble a typed Dart record. Each projected/aggregated leaf is keyed by a
+// deterministic alias derived from its field path + operation.
+// ---------------------------------------------------------------------------
+
+/// Context handed to a pipeline selector when building a `select` / `aggregate`
+/// stage. Implementations either capture the native pieces or resolve values
+/// from a result row.
+abstract class PipelineContext {
+  R aggregate<R>(String alias, firestore.PipelineAggregateFunction Function() fn);
+  R project<R>(String alias, firestore.Field Function() field);
 }
 
-/// A type-safe leaf for a scalar field in a pipeline selector.
+class _CaptureContext implements PipelineContext {
+  final List<firestore.AliasedAggregateFunction> aggregates = [];
+  final List<firestore.Selectable> projections = [];
+
+  @override
+  R aggregate<R>(
+    String alias,
+    firestore.PipelineAggregateFunction Function() fn,
+  ) {
+    aggregates.add(fn().as(alias));
+    return defaultValue<R>();
+  }
+
+  @override
+  R project<R>(String alias, firestore.Field Function() field) {
+    projections.add(field().alias(alias));
+    return defaultValue<R>();
+  }
+}
+
+class _RowContext implements PipelineContext {
+  final Map<String, dynamic> row;
+  _RowContext(this.row);
+
+  R _coerce<R>(Object? value) {
+    if (value is R) return value;
+    if (value is num) {
+      if (R == int) return value.toInt() as R;
+      if (R == double) return value.toDouble() as R;
+    }
+    return value as R;
+  }
+
+  @override
+  R aggregate<R>(String alias, firestore.PipelineAggregateFunction Function() _) =>
+      _coerce<R>(row[alias]);
+
+  @override
+  R project<R>(String alias, firestore.Field Function() _) =>
+      _coerce<R>(row[alias]);
+}
+
+/// Base class for generated per-model pipeline selectors. Mirrors
+/// `FilterBuilderNode` / `OrderByFieldNode`: each node carries its [FieldPath];
+/// nested objects are nested selectors. The optional [$ctx] is present only when
+/// the selector is used inside a `select` / `aggregate` builder.
+class PipelineFieldNode extends Node {
+  final PipelineContext? $ctx;
+  const PipelineFieldNode({super.field, PipelineContext? context})
+    : $ctx = context;
+
+  /// Count of all rows, for `aggregate(($) => (n: $.count()))`.
+  int count() =>
+      $ctx!.aggregate<int>('count_all', () => firestore.CountAll());
+}
+
+/// A type-safe leaf for a scalar field. Produces native pipeline
+/// expressions/orderings/aggregates **from the field's path** — never a string.
 ///
-/// It produces native pipeline expressions/orderings/aggregates **from the
-/// field's path** — callers never spell the path as a string. The ergonomics
-/// mirror the classic ODM query API:
-///
+/// Ergonomics mirror the classic ODM API:
 /// ```dart
-/// $.age(isGreaterThanOrEqualTo: 18)   // where  -> BooleanExpression
-/// $.age.descending()                  // sort   -> Ordering
-/// $.age.sum().as('total')             // select/aggregate
+/// $.age(isGreaterThanOrEqualTo: 18)   // where   -> BooleanExpression
+/// $.age.descending()                  // sort    -> Ordering
+/// $.age.sum()                         // aggregate (inside aggregate(...))
+/// $.name.value                        // project  (inside select(...))
 /// ```
 class PipelineField<T> extends PipelineFieldNode {
-  const PipelineField({super.field, Object? Function(T)? toJson})
+  const PipelineField({super.field, super.context, Object? Function(T)? toJson})
     : _toJson = toJson;
 
-  /// Converts a typed value to its Firestore JSON form (e.g. enum → its
-  /// `@JsonValue`, DateTime → ISO string), matching how the field is stored.
   final Object? Function(T)? _toJson;
 
-  /// The underlying native field expression for this leaf's path.
   firestore.Field get expression => firestore.Field(path.path);
+
+  String get _alias => path.path;
 
   Object? _json(T value) => _toJson != null ? _toJson(value) : value;
 
-  /// Build a `where` predicate, mirroring the classic filter API. Exactly one
-  /// argument should be supplied.
+  /// `where` predicate (exactly one comparison), mirroring the classic filter.
   firestore.BooleanExpression call({
     Object? isEqualTo = _sentinel,
     Object? isNotEqualTo = _sentinel,
@@ -78,28 +143,43 @@ class PipelineField<T> extends PipelineFieldNode {
     throw ArgumentError('Provide exactly one comparison to a pipeline where()');
   }
 
-  /// Ascending sort on this field.
+  /// Ascending / descending sort on this field.
   firestore.Ordering ascending() => expression.ascending();
-
-  /// Descending sort on this field.
   firestore.Ordering descending() => expression.descending();
+
+  /// Project this field's value, for use inside `select(...)`.
+  T get value => $ctx!.project<T>(_alias, () => expression);
+
+  /// Aggregates, for use inside `aggregate(...)`.
+  T sum() => $ctx!.aggregate<T>('sum_$_alias', () => expression.sum());
+  double average() =>
+      $ctx!.aggregate<double>('avg_$_alias', () => expression.average());
+  T minimum() => $ctx!.aggregate<T>('min_$_alias', () => expression.minimum());
+  T maximum() => $ctx!.aggregate<T>('max_$_alias', () => expression.maximum());
+  int countField() =>
+      $ctx!.aggregate<int>('count_$_alias', () => expression.count());
 }
 
 const Object _sentinel = Object();
 
 /// A type-safe wrapper over a Firestore [firestore.Pipeline] that keeps the
-/// model element type `T` and exposes the generated selector `S` for building
-/// stages without string field paths.
+/// model element type `T` and exposes the generated selector `S` so stages are
+/// built with `$.field`, never string paths.
 ///
 /// **Experimental** — Pipelines are a Firestore **Enterprise edition** feature:
-/// one-shot `execute()` (no realtime/offline), and unsupported by the emulator
-/// or `fake_cloud_firestore`. Execution must be validated against a real
-/// Enterprise database; see `docs/adr/0001-firestore-pipelines.md`.
+/// one-shot `execute()` (no realtime/offline), unsupported by the emulator or
+/// `fake_cloud_firestore`. The `select` / `aggregate` projections are
+/// **compile-time type-checked but their runtime behaviour is unverified**
+/// pending an Enterprise test database. See
+/// `docs/adr/0001-firestore-pipelines.md`.
 class TypedPipeline<T, S extends PipelineFieldNode> {
   final firestore.Pipeline _pipeline;
   final T Function(Map<String, dynamic>) _fromJson;
   final String _documentIdField;
-  final S _selector;
+
+  /// Builds the generated selector, optionally bound to a [PipelineContext]
+  /// (used by `select`/`aggregate`).
+  final S Function(PipelineContext? context) _selector;
 
   const TypedPipeline(
     this._pipeline,
@@ -111,38 +191,29 @@ class TypedPipeline<T, S extends PipelineFieldNode> {
   TypedPipeline<T, S> _next(firestore.Pipeline p) =>
       TypedPipeline(p, _fromJson, _documentIdField, _selector);
 
-  /// `where` stage built from the typed selector, e.g.
-  /// `pipeline.where(($) => $.age(isGreaterThanOrEqualTo: 18))`.
+  // --- row-type-preserving stages -----------------------------------------
+
   TypedPipeline<T, S> where(
     firestore.BooleanExpression Function(S selector) build,
-  ) => _next(_pipeline.where(build(_selector)));
+  ) => _next(_pipeline.where(build(_selector(null))));
 
-  /// `sort` stage, e.g. `pipeline.sort(($) => $.age.descending())`. Up to three
-  /// orderings; extend as needed.
   TypedPipeline<T, S> sort(
     firestore.Ordering Function(S selector) build, [
     firestore.Ordering Function(S selector)? build2,
     firestore.Ordering Function(S selector)? build3,
   ]) {
-    final o1 = build(_selector);
-    if (build3 != null) {
-      return _next(_pipeline.sort(o1, build2!(_selector), build3(_selector)));
-    }
-    if (build2 != null) {
-      return _next(_pipeline.sort(o1, build2(_selector)));
-    }
+    final s = _selector(null);
+    final o1 = build(s);
+    if (build3 != null) return _next(_pipeline.sort(o1, build2!(s), build3(s)));
+    if (build2 != null) return _next(_pipeline.sort(o1, build2(s)));
     return _next(_pipeline.sort(o1));
   }
 
-  /// `limit` stage.
   TypedPipeline<T, S> limit(int limit) => _next(_pipeline.limit(limit));
-
-  /// `offset` stage.
   TypedPipeline<T, S> offset(int offset) => _next(_pipeline.offset(offset));
 
   /// Executes the pipeline (Enterprise edition; one-shot) and maps each result
-  /// row through the model's `fromJson`. The document id is injected into the
-  /// model's document-id field when a row carries a document reference.
+  /// row through the model's `fromJson`, injecting the document id when present.
   Future<List<T>> execute({firestore.ExecuteOptions? options}) async {
     final snapshot = await _pipeline.execute(options: options);
     return [for (final row in snapshot.result) _fromJson(_withId(row))];
@@ -155,5 +226,103 @@ class TypedPipeline<T, S extends PipelineFieldNode> {
       data[_documentIdField] = id;
     }
     return data;
+  }
+
+  // --- shape-changing stages (typed records) ------------------------------
+
+  /// Project each row into a typed record, e.g.
+  /// `select(($) => (name: $.name.value, years: $.age.value))`.
+  ProjectedPipeline<R> select<R>(R Function(S selector) build) {
+    final capture = _CaptureContext();
+    build(_selector(capture)); // capture phase
+    final p = _applySelect(_pipeline, capture.projections);
+    return ProjectedPipeline<R>._(p, (row) => build(_selector(_RowContext(row))));
+  }
+
+  /// Aggregate the (filtered) pipeline into a single typed record, e.g.
+  /// `aggregate(($) => (count: $.count(), avgAge: $.age.average()))`.
+  Future<R> aggregate<R>(R Function(S selector) build) async {
+    final capture = _CaptureContext();
+    build(_selector(capture)); // capture phase
+    final p = _applyAggregate(_pipeline, capture.aggregates);
+    final snapshot = await p.execute();
+    final row = snapshot.result.isNotEmpty
+        ? (snapshot.result.first.data() ?? const {})
+        : const <String, dynamic>{};
+    return build(_selector(_RowContext(Map<String, dynamic>.from(row))));
+  }
+}
+
+/// The result of a `select` projection: execute it to get typed records.
+class ProjectedPipeline<R> {
+  final firestore.Pipeline _pipeline;
+  final R Function(Map<String, dynamic> row) _build;
+  const ProjectedPipeline._(this._pipeline, this._build);
+
+  Future<List<R>> execute({firestore.ExecuteOptions? options}) async {
+    final snapshot = await _pipeline.execute(options: options);
+    return [
+      for (final row in snapshot.result)
+        _build(Map<String, dynamic>.from(row.data() ?? const {})),
+    ];
+  }
+}
+
+// cloud_firestore's `aggregate`/`select` take positional (not list) arguments;
+// fan a captured list out to the positional API (supports up to 10 — extend if
+// needed).
+firestore.Pipeline _applyAggregate(
+  firestore.Pipeline p,
+  List<firestore.AliasedAggregateFunction> a,
+) {
+  switch (a.length) {
+    case 0:
+      throw ArgumentError('aggregate() needs at least one aggregate function');
+    case 1:
+      return p.aggregate(a[0]);
+    case 2:
+      return p.aggregate(a[0], a[1]);
+    case 3:
+      return p.aggregate(a[0], a[1], a[2]);
+    case 4:
+      return p.aggregate(a[0], a[1], a[2], a[3]);
+    case 5:
+      return p.aggregate(a[0], a[1], a[2], a[3], a[4]);
+    case 6:
+      return p.aggregate(a[0], a[1], a[2], a[3], a[4], a[5]);
+    case 7:
+      return p.aggregate(a[0], a[1], a[2], a[3], a[4], a[5], a[6]);
+    case 8:
+      return p.aggregate(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]);
+    default:
+      throw ArgumentError('aggregate() supports up to 8 functions for now');
+  }
+}
+
+firestore.Pipeline _applySelect(
+  firestore.Pipeline p,
+  List<firestore.Selectable> s,
+) {
+  switch (s.length) {
+    case 0:
+      throw ArgumentError('select() needs at least one field');
+    case 1:
+      return p.select(s[0]);
+    case 2:
+      return p.select(s[0], s[1]);
+    case 3:
+      return p.select(s[0], s[1], s[2]);
+    case 4:
+      return p.select(s[0], s[1], s[2], s[3]);
+    case 5:
+      return p.select(s[0], s[1], s[2], s[3], s[4]);
+    case 6:
+      return p.select(s[0], s[1], s[2], s[3], s[4], s[5]);
+    case 7:
+      return p.select(s[0], s[1], s[2], s[3], s[4], s[5], s[6]);
+    case 8:
+      return p.select(s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]);
+    default:
+      throw ArgumentError('select() supports up to 8 fields for now');
   }
 }

--- a/packages/firestore_odm/pubspec.yaml
+++ b/packages/firestore_odm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firestore_odm
 description: Type-safe Firestore ODM with code generation support. Generate type-safe Firestore operations with annotations.
-version: 4.0.0
+version: 4.1.0-dev.1
 homepage: https://github.com/SylphxAI/firestore_odm
 repository: https://github.com/SylphxAI/firestore_odm
 issue_tracker: https://github.com/SylphxAI/firestore_odm/issues

--- a/packages/firestore_odm_annotation/CHANGELOG.md
+++ b/packages/firestore_odm_annotation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.0-dev.1
+
+- Bump version to match other packages (typed pipeline API).
+
 ## 4.0.0
 
 Stable release of the 4.0 line (version kept in lockstep with the other

--- a/packages/firestore_odm_annotation/pubspec.yaml
+++ b/packages/firestore_odm_annotation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firestore_odm_annotation
 description: Pure annotations for Firestore ODM code generation. Provides the core annotations used to generate type-safe Firestore ODM code.
-version: 4.0.0
+version: 4.1.0-dev.1
 homepage: https://github.com/SylphxAI/firestore_odm
 repository: https://github.com/SylphxAI/firestore_odm
 issue_tracker: https://github.com/SylphxAI/firestore_odm/issues

--- a/packages/firestore_odm_builder/CHANGELOG.md
+++ b/packages/firestore_odm_builder/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.1.0-dev.1
+
+- Generate a fully type-safe pipeline surface per (non-generic) model:
+  `<Model>PipelineSelector` (typed `$.field` leaves) + a covariant `pipeline()`
+  extension on the model's collection. Replaces the string-based experimental
+  pipeline API. See `docs/adr/0001-firestore-pipelines.md`.
+
 ## 4.0.0
 
 Stable release of the 4.0 line. Key change since 3.x: migrated to the analyzer

--- a/packages/firestore_odm_builder/lib/src/generators/pipeline_generator.dart
+++ b/packages/firestore_odm_builder/lib/src/generators/pipeline_generator.dart
@@ -44,7 +44,10 @@ class PipelineGenerator {
           ..symbol = '${field.type.element!.name}PipelineSelector'
           ..types.addAll(field.type.typeArguments.map((t) => t.reference)),
       );
-      instance = leafType.newInstance([], {'field': fieldPath});
+      instance = leafType.newInstance([], {
+        'field': fieldPath,
+        'context': refer('\$ctx'),
+      });
     } else {
       leafType = TypeReference(
         (b) => b
@@ -53,6 +56,7 @@ class PipelineGenerator {
       );
       instance = leafType.newInstance([], {
         'field': fieldPath,
+        'context': refer('\$ctx'),
         'toJson': ConverterGenerator.getToJsonEnsured(
           type: field.type,
           customConverter: field.customConverter,
@@ -81,14 +85,20 @@ class PipelineGenerator {
         ..constructors.add(
           Constructor(
             (b) => b
-              ..optionalParameters.add(
+              ..optionalParameters.addAll([
                 Parameter(
                   (b) => b
                     ..name = 'field'
                     ..toSuper = true
                     ..named = true,
                 ),
-              ),
+                Parameter(
+                  (b) => b
+                    ..name = 'context'
+                    ..toSuper = true
+                    ..named = true,
+                ),
+              ]),
           ),
         )
         ..fields.addAll([for (final f in fields.values) _leaf(f)]),
@@ -140,7 +150,15 @@ class PipelineGenerator {
       ).call([refer('query').property('path')]),
       refer('fromJson'),
       refer('documentIdField'),
-      selector.newInstance([]),
+      // Selector factory: `(context) => <Model>PipelineSelector(context: context)`.
+      Method(
+        (b) => b
+          ..lambda = true
+          ..requiredParameters.add(Parameter((b) => b..name = 'context'))
+          ..body = selector.newInstance([], {
+            'context': refer('context'),
+          }).code,
+      ).closure,
     ]);
 
     return Extension(

--- a/packages/firestore_odm_builder/lib/src/generators/pipeline_generator.dart
+++ b/packages/firestore_odm_builder/lib/src/generators/pipeline_generator.dart
@@ -1,0 +1,164 @@
+import 'package:analyzer/dart/element/type.dart' hide FunctionType;
+import 'package:code_builder/code_builder.dart';
+import 'package:firestore_odm_builder/src/utils/reference_utils.dart';
+import '../utils/model_analyzer.dart';
+import 'converter_generator.dart';
+
+/// Generator for the **experimental** type-safe Firestore Pipelines surface.
+///
+/// For each (non-generic) model it generates:
+/// - `<Model>PipelineSelector` — a field-path selector whose leaves are
+///   `PipelineField<T>` (and nested selectors for nested objects), so callers
+///   build pipeline stages with `$.field` instead of string `Field('path')`.
+/// - a `pipeline()` extension on the model's `FirestoreCollection`, returning a
+///   `TypedPipeline<Model, <Model>PipelineSelector>`.
+///
+/// Generic models are skipped for now (documented in ADR-0001) — pipelines are
+/// experimental and generic-model support can follow.
+class PipelineGenerator {
+  /// Whether a pipeline surface can be generated for [type]. Generic models are
+  /// skipped (their collection type — and the selector — would need the type
+  /// parameters threaded through, which is deferred).
+  static bool isSupported(InterfaceType type) =>
+      type.element.typeParameters.isEmpty;
+
+  static List<Spec> generate({required InterfaceType type}) {
+    if (!isSupported(type)) return const [];
+    return [_selectorClass(type), _pipelineExtension(type)];
+  }
+
+  static String selectorName(InterfaceType type) =>
+      '${type.element.name}PipelineSelector';
+
+  static Field _leaf(FieldInfo field) {
+    final fieldPath = field.isDocumentId
+        ? refer('FieldPath.documentId')
+        : refer('path').property('append').call([literalString(field.jsonName)]);
+
+    final TypeReference leafType;
+    final Expression instance;
+    if (isUserType(field.type)) {
+      // Nested object -> nested selector.
+      leafType = TypeReference(
+        (b) => b
+          ..symbol = '${field.type.element!.name}PipelineSelector'
+          ..types.addAll(field.type.typeArguments.map((t) => t.reference)),
+      );
+      instance = leafType.newInstance([], {'field': fieldPath});
+    } else {
+      leafType = TypeReference(
+        (b) => b
+          ..symbol = 'PipelineField'
+          ..types.add(field.type.reference),
+      );
+      instance = leafType.newInstance([], {
+        'field': fieldPath,
+        'toJson': ConverterGenerator.getToJsonEnsured(
+          type: field.type,
+          customConverter: field.customConverter,
+        ),
+      });
+    }
+
+    return Field(
+      (b) => b
+        ..docs.add('/// Pipeline selector for `${field.parameterName}`')
+        ..name = field.parameterName
+        ..modifier = FieldModifier.final$
+        ..late = true
+        ..type = leafType
+        ..assignment = instance.code,
+    );
+  }
+
+  static Class _selectorClass(InterfaceType type) {
+    final fields = getFields(type);
+    return Class(
+      (b) => b
+        ..name = selectorName(type)
+        ..docs.add('/// Generated pipeline selector for `${type.element.name}`')
+        ..extend = refer('PipelineFieldNode')
+        ..constructors.add(
+          Constructor(
+            (b) => b
+              ..optionalParameters.add(
+                Parameter(
+                  (b) => b
+                    ..name = 'field'
+                    ..toSuper = true
+                    ..named = true,
+                ),
+              ),
+          ),
+        )
+        ..fields.addAll([for (final f in fields.values) _leaf(f)]),
+    );
+  }
+
+  /// A `pipeline()` extension on the model's collection. The `on` type uses the
+  /// type-parameter *bounds* for everything except the model `T`; because
+  /// Firestore's collection generics are covariant, the concrete
+  /// `db.<collection>` (e.g. `FirestoreCollection<TestSchema, User, ...>`)
+  /// is a subtype, so the extension applies and dispatches on the model.
+  static Extension _pipelineExtension(InterfaceType type) {
+    final modelRef = type.reference;
+    final selector = TypeReference((b) => b..symbol = selectorName(type));
+
+    final onType = TypeReference(
+      (b) => b
+        ..symbol = 'FirestoreCollection'
+        ..types.addAll([
+          refer('FirestoreSchema'),
+          modelRef,
+          refer('Record'),
+          TypeReference(
+            (b) => b
+              ..symbol = 'PatchBuilder'
+              ..types.addAll([
+                modelRef,
+                TypeReferences.mapOf(
+                  TypeReferences.string,
+                  TypeReferences.dynamic,
+                ).withNullability(true),
+              ]),
+          ),
+          refer('FilterBuilderRoot'),
+          refer('OrderByFieldNode'),
+          refer('AggregateBuilderRoot'),
+        ]),
+    );
+
+    final returnType = TypeReference(
+      (b) => b
+        ..symbol = 'TypedPipeline'
+        ..types.addAll([modelRef, selector]),
+    );
+
+    final body = returnType.newInstance([
+      refer('query').property('firestore').property('pipeline').call([]).property(
+        'collection',
+      ).call([refer('query').property('path')]),
+      refer('fromJson'),
+      refer('documentIdField'),
+      selector.newInstance([]),
+    ]);
+
+    return Extension(
+      (b) => b
+        ..name = '${type.element.name}PipelineExtension'
+        ..docs.add(
+          '/// **Experimental** type-safe Firestore Pipeline for `${type.element.name}`.',
+        )
+        ..on = onType
+        ..methods.add(
+          Method(
+            (b) => b
+              ..name = 'pipeline'
+              ..returns = returnType
+              ..lambda = true
+              ..body = body.code,
+          ),
+        ),
+    );
+  }
+}

--- a/packages/firestore_odm_builder/lib/src/generators/pipeline_generator.dart
+++ b/packages/firestore_odm_builder/lib/src/generators/pipeline_generator.dart
@@ -33,7 +33,9 @@ class PipelineGenerator {
   static Field _leaf(FieldInfo field) {
     final fieldPath = field.isDocumentId
         ? refer('FieldPath.documentId')
-        : refer('path').property('append').call([literalString(field.jsonName)]);
+        : refer(
+            'path',
+          ).property('append').call([literalString(field.jsonName)]);
 
     final TypeReference leafType;
     final Expression instance;
@@ -145,9 +147,12 @@ class PipelineGenerator {
     );
 
     final body = returnType.newInstance([
-      refer('query').property('firestore').property('pipeline').call([]).property(
-        'collection',
-      ).call([refer('query').property('path')]),
+      refer('query')
+          .property('firestore')
+          .property('pipeline')
+          .call([])
+          .property('collection')
+          .call([refer('query').property('path')]),
       refer('fromJson'),
       refer('documentIdField'),
       // Selector factory: `(context) => <Model>PipelineSelector(context: context)`.
@@ -155,9 +160,7 @@ class PipelineGenerator {
         (b) => b
           ..lambda = true
           ..requiredParameters.add(Parameter((b) => b..name = 'context'))
-          ..body = selector.newInstance([], {
-            'context': refer('context'),
-          }).code,
+          ..body = selector.newInstance([], {'context': refer('context')}).code,
       ).closure,
     ]);
 

--- a/packages/firestore_odm_builder/lib/src/model_builder_generator.dart
+++ b/packages/firestore_odm_builder/lib/src/model_builder_generator.dart
@@ -6,6 +6,7 @@ import 'package:firestore_odm_builder/src/generators/aggregate_generator.dart';
 import 'package:firestore_odm_builder/src/generators/converter_generator.dart';
 import 'package:firestore_odm_builder/src/generators/filter_generator.dart';
 import 'package:firestore_odm_builder/src/generators/order_by_generator.dart';
+import 'package:firestore_odm_builder/src/generators/pipeline_generator.dart';
 import 'package:firestore_odm_builder/src/generators/update_generator.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -34,6 +35,8 @@ class ModelBuilderGenerator extends GeneratorForAnnotation<FirestoreOdm> {
     specs.addAll(OrderByGenerator.generateOrderByClasses(element.thisType));
 
     specs.addAll(AggregateGenerator.generateClasses(element.thisType));
+
+    specs.addAll(PipelineGenerator.generate(type: element.thisType));
 
     specs.addAll(ConverterGenerator.generate(type: element.thisType));
 

--- a/packages/firestore_odm_builder/pubspec.yaml
+++ b/packages/firestore_odm_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firestore_odm_builder
 description: Code generator for Firestore ODM annotations. Generates type-safe Firestore operations from annotated classes.
-version: 4.0.0
+version: 4.1.0-dev.1
 homepage: https://github.com/SylphxAI/firestore_odm
 repository: https://github.com/SylphxAI/firestore_odm
 issue_tracker: https://github.com/SylphxAI/firestore_odm/issues


### PR DESCRIPTION
Replaces the 4.0.0 experimental **string-based** pipeline API (`Field('age')`) with a **fully type-safe** one built on the same generated `$.field` selector as the rest of the ODM. The string API contradicted the library's whole purpose (eliminating string field paths); this fixes that.

## API
```dart
// row-preserving -> List<User>
await db.users.pipeline()
  .where(($) => $.age(isGreaterThanOrEqualTo: 18))   // typed value; nested $.profile.x works
  .sort(($) => $.age.descending())
  .limit(20)
  .execute();

// select -> typed records
await db.users.pipeline()
  .select(($) => (name: $.name.value, years: $.age.value))
  .execute();                                          // List<({String name, int years})>

// aggregate -> a typed record
await db.users.pipeline()
  .aggregate(($) => (count: $.count(), avgAge: $.age.average()));  // ({int count, double avgAge})
```

## How
- New `pipeline_generator.dart`: per non-generic model, `<Model>PipelineSelector` (typed `$.field` leaves carrying their FieldPath + toJson; nested objects = nested selectors) + a covariant `pipeline()` extension on the collection.
- Runtime `TypedPipeline<T, S>` + dual-phase replay for `select`/`aggregate` (capture builds the native stage under deterministic aliases; result pass replays the record-builder per row to reassemble typed records, with numeric coercion) — mirrors the classic aggregate subsystem.

## Verification & limits
- format/analyze clean; **full suite green (507)**; pipeline builder type-safety covered by compile-time tests.
- Pipelines are **Enterprise-edition only** and unsupported by `fake_cloud_firestore` — so `where/sort/limit` are compile-verified and **`select`/`aggregate` runtime behaviour is compile-verified only**, pending validation on a real Enterprise DB. Marked experimental.
- Generic models don't get a pipeline surface yet (follow-up).

Design: `docs/adr/0001-firestore-pipelines.md`. Refs #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)