### PR TITLE
docs: adopt doctrine project manifest

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -1,0 +1,140 @@
+{
+  "schemaVersion": 1,
+  "project": {
+    "repo": "SylphxAI/firestore_odm",
+    "name": "Firestore ODM",
+    "lifecycle": "production",
+    "layer": "foundation",
+    "summary": "Firestore ODM is a production Dart/Flutter package ecosystem for type-safe Firestore access through annotations and code generation.",
+    "goals": [
+      "Own Firestore ODM annotations, runtime package, builder package, generated API semantics, example app, documentation, CI, and pub.dev release workflow.",
+      "Keep Firestore data access type-safe, generated, benchmarked, and compatible with supported Dart/Flutter versions.",
+      "Publish packages only with CI, dry-run/publish proof, pub.dev readback, and documentation evidence."
+    ],
+    "nonGoals": [
+      "Own downstream app schemas, Firebase projects, Firestore security rules, or tenant data models.",
+      "Encode app-specific Firestore behavior into the generic ODM.",
+      "Rely on source revert for already-published pub.dev packages."
+    ]
+  },
+  "boundaries": {
+    "owns": [
+      {
+        "name": "firestore-odm-package-ecosystem",
+        "description": "Annotation, runtime, and builder packages plus their public generated API semantics."
+      },
+      {
+        "name": "firestore-odm-docs-and-release",
+        "description": "Documentation, example app, CI evidence, pub.dev publishing, and release verification for Firestore ODM packages."
+      }
+    ],
+    "doesNotOwn": [
+      "Downstream app schemas, Firebase projects, Firestore security rules, or tenant data models.",
+      "The Firebase/Firestore platform, pub.dev registry, or GitHub Pages platform.",
+      "Enterprise doctrine or org-wide release/ruleset ownership."
+    ],
+    "publicSurfaces": [
+      {
+        "type": "package-export",
+        "name": "Firestore ODM pub packages",
+        "location": "packages/*/pubspec.yaml"
+      },
+      {
+        "type": "documentation",
+        "name": "Firestore ODM documentation",
+        "location": "docs/"
+      },
+      {
+        "type": "workflow",
+        "name": "CI and release workflows",
+        "location": ".github/workflows/"
+      },
+      {
+        "type": "status-context",
+        "name": "Required branch contexts",
+        "location": "ci-success, coverage, docs, performance, quality, security"
+      }
+    ],
+    "allowedDependencies": [
+      {
+        "repo": "SylphxAI/doctrine",
+        "surface": "enterprise engineering doctrine",
+        "direction": "downward"
+      }
+    ],
+    "forbiddenCouplings": [
+      "Do not encode downstream app-specific Firestore behavior into the generic ODM.",
+      "Do not publish packages without dry-run/publish proof and pub.dev readback.",
+      "Do not rely on source revert for already-published pub.dev versions."
+    ]
+  },
+  "documentation": {
+    "adr": {
+      "path": "docs/adr/",
+      "status": "planned"
+    },
+    "specs": {
+      "path": "docs/README.md",
+      "status": "present"
+    },
+    "catalog": {
+      "path": "PROJECT.md",
+      "status": "present"
+    },
+    "runbooks": {
+      "path": ".github/workflows/release.yml",
+      "status": "present"
+    },
+    "generatedReferences": {
+      "path": "packages/*/lib/**/*.g.dart",
+      "status": "generated"
+    }
+  },
+  "delivery": {
+    "ciModel": "legacy-ci",
+    "requiredContexts": [
+      "ci-success",
+      "coverage",
+      "docs",
+      "performance",
+      "quality",
+      "security"
+    ],
+    "deployPath": "Release workflow publishes pub.dev packages and GitHub releases on tag/manual publish paths; docs workflow deploys documentation.",
+    "productionProof": "Required CI contexts, dry-run/publish output, pub.dev readback, docs readback, and generated-code smoke tests.",
+    "recoveryClass": "forward-fix-only",
+    "packageRelease": {
+      "publishesPackages": true,
+      "ecosystems": [
+        "pub.dev",
+        "github-release"
+      ],
+      "releaseIntent": "Tags or manual release workflow inputs control pub.dev release intent.",
+      "versionPr": "Melos/package version changes must be reviewed before tag/manual publish.",
+      "publisher": "GitHub Actions release workflow with PUB_CREDENTIALS.",
+      "requiredContexts": [
+        "ci-success",
+        "quality",
+        "security"
+      ],
+      "publishProof": "pub.dev readback for firestore_odm_annotation, firestore_odm, and firestore_odm_builder."
+    }
+  },
+  "adoption": {
+    "status": "baseline",
+    "gaps": [
+      {
+        "id": "central-admission",
+        "description": "CI is repo-local legacy GitHub Actions; migrate to central admission or stable status fan-in when the fleet workflow is ready.",
+        "owner": "SylphxAI/firestore_odm",
+        "target": "before full doctrine adoption"
+      },
+      {
+        "id": "release-version-pr",
+        "description": "Clarify bot-owned version PR and publish evidence policy for pub.dev releases.",
+        "owner": "SylphxAI/firestore_odm",
+        "target": "before claiming full package-release adoption"
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Agent Instructions
+
+Engineering doctrine: https://github.com/SylphxAI/doctrine
+
+Before changing behavior, read `PROJECT.md`, `.doctrine/project.json`, the
+central doctrine entry points, and triggered doctrine standards. This file is a
+thin runtime adapter; keep enterprise policy in doctrine.
+
+## Local Commands
+
+- `melos bootstrap` - bootstrap workspace packages.
+- `melos run check --no-select` - format, analyze, and tests.
+- `melos run publish:dry-run --no-select` - validate pub.dev publishability.
+- `melos run generate` - generate code where needed.
+
+## Local Hazards
+
+- Firestore ODM is a public Dart/Flutter code-generation package ecosystem.
+  Builder output, annotations, generated APIs, and Firestore write semantics are
+  public contracts.
+- pub.dev package publishes are forward-fix-only.
+- Example app and generated-code tests may need Flutter/Firebase context.
+
+## Reporting
+
+Separate local diff, PR state, CI state, merge state, pub.dev publish state,
+docs publish state, and package readback proof.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,57 @@
+# Firestore ODM Project
+
+Firestore ODM is a production Dart/Flutter package ecosystem for type-safe
+Firestore access through annotations and code generation. It publishes
+`firestore_odm`, `firestore_odm_annotation`, and `firestore_odm_builder`.
+
+## Goals
+
+- Own Firestore ODM annotations, runtime package, builder package, generated API
+  semantics, example app, documentation, CI, and pub.dev release workflow.
+- Keep Firestore data access type-safe, generated, benchmarked, and compatible
+  with supported Dart/Flutter versions.
+- Publish packages only with CI, dry-run/publish proof, pub.dev readback, and
+  documentation evidence.
+
+## Non-Goals
+
+- Do not own downstream app schemas, Firebase projects, Firestore security
+  rules, or tenant data models.
+- Do not encode app-specific Firestore behavior into the generic ODM.
+- Do not rely on source revert for already-published pub.dev packages.
+
+## Boundaries
+
+Owned contexts are the annotation package, runtime package, builder package,
+generated code contract, example app, docs, package versions, and release
+workflow. Downstream apps consume only pub.dev packages and documented APIs.
+
+Public surfaces:
+
+- pub.dev packages under `packages/*/pubspec.yaml`.
+- Documentation under `docs/` and GitHub Pages.
+- Required contexts `quality`, `security`, `docs`, `performance`, `coverage`,
+  and `ci-success`.
+- Release workflow `.github/workflows/release.yml`.
+
+## Delivery
+
+Current CI model: `legacy-ci`. Required contexts are `quality`, `security`,
+`docs`, `performance`, `coverage`, and `ci-success`.
+
+Release path: tag or manual release workflow dry-runs/publishes packages to
+pub.dev, creates a GitHub release, and verifies publication. Production proof
+must include required CI, dry-run/publish output, pub.dev readback, docs
+readback, and generated-code smoke tests.
+
+Recovery class: `forward-fix-only`, because pub.dev package versions and
+generated downstream APIs cannot be fully undone by source revert.
+
+## References
+
+- Machine manifest: `.doctrine/project.json`
+- Public docs: `docs/README.md`
+- Package manifests: `packages/*/pubspec.yaml`
+- CI: `.github/workflows/ci.yml`
+- Release: `.github/workflows/release.yml`
+- Doctrine: https://github.com/SylphxAI/doctrine


### PR DESCRIPTION
## Summary
- Add PROJECT.md and .doctrine/project.json for doctrine project-control-plane adoption.
- Add a thin AGENTS.md runtime adapter.
- Record Firestore ODM package boundaries, required contexts, forward-only pub.dev recovery, package release facts, and adoption gaps.

## Validation
- jq empty .doctrine/project.json
- git diff --check
- python3 /Users/kyle/.doctrine/scripts/project-control-plane-audit.py --local . --fail-on-drift --json -> PRESENT

## Scope
Docs/control-plane only. No runtime, CI, deployment, dependency, secret, or infrastructure changes.