### PR TITLE
ci: replace non-matching self-hosted label with ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   # Code quality checks
   quality:
-    runs-on: [self-hosted, sylphx, linux, standard]
+    runs-on: ubuntu-latest
     steps:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
@@ -102,7 +102,7 @@ jobs:
 
   # Code coverage
   coverage:
-    runs-on: [self-hosted, sylphx, linux, standard]
+    runs-on: ubuntu-latest
     needs: [quality, test]
     steps:
       - name: 📚 Git Checkout
@@ -157,7 +157,7 @@ jobs:
 
   # Performance testing
   performance:
-    runs-on: [self-hosted, sylphx, linux, standard]
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     needs: [quality]
     steps:
@@ -199,7 +199,7 @@ jobs:
 
   # Security scanning
   security:
-    runs-on: [self-hosted, sylphx, linux, standard]
+    runs-on: ubuntu-latest
     steps:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
@@ -242,7 +242,7 @@ jobs:
 
   # Documentation generation test
   docs:
-    runs-on: [self-hosted, sylphx, linux, standard]
+    runs-on: ubuntu-latest
     steps:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
@@ -280,7 +280,7 @@ jobs:
 
   # CI results summary
   ci-success:
-    runs-on: [self-hosted, sylphx, linux, standard]
+    runs-on: ubuntu-latest
     needs: [quality, test, coverage, security, docs]
     if: always()
     steps:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
-    runs-on: [self-hosted, sylphx, linux, standard]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   release:
-    runs-on: [self-hosted, sylphx, linux, standard]
+    runs-on: ubuntu-latest
     steps:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
@@ -177,7 +177,7 @@ jobs:
 
   # Verify publication success
   verify-publish:
-    runs-on: [self-hosted, sylphx, linux, standard]
+    runs-on: ubuntu-latest
     if: ${{ inputs.run_publish || startsWith(github.ref, 'refs/tags/') }}
     needs: release
     steps:


### PR DESCRIPTION
## Summary
- Tip CI used non-matching runner labels `[self-hosted, sylphx, linux, standard]`.
- Switch product workflows to `ubuntu-latest` so tip checks schedule.

## Note
- Integration test failures (if still present) remain product-suite residual and are tracked separately from runner admission.

## Test plan
- [ ] Jobs start on GitHub-hosted runners
- [ ] Report unit vs integration outcomes honestly