### PR TITLE
ci: drop default merge_group (Fast Trunk MQ off)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,12 @@
 name: CI
 
 on:
+  # No merge_group — Merge Queue off by default (Fast Trunk).
   workflow_dispatch: # Manual trigger
   push:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
-  merge_group:
-    types: [checks_requested]
 
 # Flutter is pinned to the current stable, 3.44.2 (Dart 3.12.2), deliberately —
 # bump it on purpose, don't float `channel: stable` (silent drift previously


### PR DESCRIPTION
## Summary

Fleet Fast Trunk alignment: remove default `merge_group` from ordinary CI (Merge Queue off unless intentionally enabled).

Does not change publish/release packaging authority paths.

## Test plan
- [ ] CI triggers on PR/push only
- [ ] No merge_group under `on:` for tip CI
