### PR TITLE
ci: wire merge_group for Merge Queue admission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  # No merge_group — Merge Queue off by default (Fast Trunk).
+  merge_group:
   workflow_dispatch: # Manual trigger
   push:
     branches: [main, develop]
@@ -22,7 +22,7 @@ on:
 
 concurrency:
   # Fast Trunk: supersede obsolete runs for the same PR or branch tip.
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Wire primary CI merge_group for Agent-Native Queued Trunk (ADR-20260803 / skills#83).

Only primary CI workflows are triggered on the queue to avoid admission fan-out.